### PR TITLE
Fix Jest configuration for test environment

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -43,7 +43,7 @@ module.exports = {
   setupFiles: ['./jest.setup.js'],
   
   // テスト実行前後のグローバル設定
-  setupFilesAfterEnv: ['./__tests__/setup.js'],
+  setupFilesAfterEnv: ['./src/setupTests.js'],
   
   // テストタイムアウト設定
   testTimeout: 10000,

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -5,8 +5,6 @@
  * テスト実行に必要な環境変数のデフォルト値とモックの設定
  */
 
-// Jest DOM拡張のインポート
-import '@testing-library/jest-dom';
 
 // テスト環境変数の設定
 process.env = {


### PR DESCRIPTION
## Summary
- remove `@testing-library/jest-dom` import from `jest.setup.js`
- use `src/setupTests.js` for `setupFilesAfterEnv`

## Testing
- `npm run test:all` *(fails: EHOSTUNREACH while fetching dependencies)*