### PR TITLE
Jest設定の改善

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -43,7 +43,7 @@ module.exports = {
   setupFiles: ['./jest.setup.js'],
   
   // テスト実行前後のグローバル設定
-  setupFilesAfterEnv: ['./__tests__/setup.js'],
+  setupFilesAfterEnv: ['./src/setupTests.js'],
   
   // テストタイムアウト設定
   testTimeout: 10000,

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -5,8 +5,6 @@
  * テスト実行に必要な環境変数のデフォルト値とモックの設定
  */
 
-// Jest DOM拡張のインポート
-import '@testing-library/jest-dom';
 
 // テスト環境変数の設定
 process.env = {

--- a/script/run-tests.sh
+++ b/script/run-tests.sh
@@ -271,10 +271,10 @@ debug_jest_config() {
     echo "- jest.setup.js: 見つかりません"
   fi
   
-  if [ -f "__tests__/setup.js" ]; then
-    echo "- __tests__/setup.js: 存在します"
+  if [ -f "src/setupTests.js" ]; then
+    echo "- src/setupTests.js: 存在します"
   else
-    echo "- __tests__/setup.js: 見つかりません"
+    echo "- src/setupTests.js: 見つかりません"
   fi
   
   if [ -f "custom-reporter.js" ]; then

--- a/script/setup-test-env.js
+++ b/script/setup-test-env.js
@@ -207,15 +207,11 @@ module.exports = {
     log.success(`モックファイルを作成しました: ${axiosMockFile}`);
   }
   
-  // setup.js ファイルの確認（空でも存在しているか）
-  const setupFile = './__tests__/setup.js';
+  // src/setupTests.js ファイルの確認
+  const setupFile = './src/setupTests.js';
   if (!fs.existsSync(setupFile)) {
-    const setupContent = `// テスト実行前後のグローバル設定
-import '@testing-library/jest-dom';
+    const setupContent = `import '@testing-library/jest-dom';\n`;
 
-// この後にテストグローバル設定を追加
-`;
-    
     fs.writeFileSync(setupFile, setupContent);
     log.success(`セットアップファイルを作成しました: ${setupFile}`);
   }


### PR DESCRIPTION
## 概要
- jest-domを `jest.setup.js` から削除
- `setupFilesAfterEnv` を `src/setupTests.js` に変更
- テスト環境セットアップスクリプトを `src/setupTests.js` 対応に更新
- run-tests.sh のチェック対象も更新

## テスト
- `npm run test:clean` は `rimraf` 不足で失敗
- `npm run test:all` は依存パッケージ未インストールのため実行できず