### PR TITLE
Generate test log if missing

### DIFF
--- a/script/generate-test-log.js
+++ b/script/generate-test-log.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+
+function generate() {
+  const outputDir = path.resolve('./test-results');
+  const jsonPath = path.join(outputDir, 'detailed-results.json');
+  const logPath = path.join(outputDir, 'test-log.md');
+
+  if (!fs.existsSync(jsonPath)) {
+    console.error(`detailed-results.json not found: ${jsonPath}`);
+    process.exit(1);
+  }
+
+  const data = JSON.parse(fs.readFileSync(jsonPath, 'utf-8'));
+
+  let md = '# テスト実行結果\n\n';
+  md += `実行日時: ${new Date().toLocaleString('ja-JP')}\n\n`;
+  md += '## サマリー\n\n';
+  md += `- 合計テスト数: ${data.numTotalTests}\n`;
+  md += `- 成功: ${data.numPassedTests}\n`;
+  md += `- 失敗: ${data.numFailedTests}\n`;
+  md += `- スキップ: ${data.numPendingTests}\n`;
+
+  if (data.coverageMap && data.coverageMap.total) {
+    const total = data.coverageMap.total;
+    md += '\n## カバレッジ\n\n';
+    md += '| メトリクス | パーセント |\n';
+    md += '|------------|-----------:|\n';
+    md += `| ステートメント | ${total.statements.pct} |\n`;
+    md += `| ブランチ | ${total.branches.pct} |\n`;
+    md += `| 関数 | ${total.functions.pct} |\n`;
+    md += `| 行 | ${total.lines.pct} |\n`;
+  }
+
+  fs.writeFileSync(logPath, md);
+}
+
+generate();

--- a/script/run-tests.sh
+++ b/script/run-tests.sh
@@ -878,10 +878,16 @@ if [ -f "./test-results/detailed-results.json" ] && grep -q "coverageMap" ./test
     if compare_values "$FUNCTIONS_COVERAGE" "$THRESHOLD_FUNCTIONS"; then
       echo -e "- Functions:  ${RED}${FUNCTIONS_COVERAGE}%${NC} → ${YELLOW}${THRESHOLD_FUNCTIONS}%${NC}"
     fi
-    if compare_values "$LINES_COVERAGE" "$THRESHOLD_LINES"; then
+  if compare_values "$LINES_COVERAGE" "$THRESHOLD_LINES"; then
       echo -e "- Lines:      ${RED}${LINES_COVERAGE}%${NC} → ${YELLOW}${THRESHOLD_LINES}%${NC}"
     fi
   fi
+fi
+
+# test-log.md が存在しない場合は詳細結果から生成する
+if [ ! -f "./test-results/test-log.md" ] && [ -f "./test-results/detailed-results.json" ]; then
+  print_warning "test-log.md が生成されていません。代替生成を行います..."
+  node ./script/generate-test-log.js && print_success "test-log.md を生成しました" || print_error "test-log.md の生成に失敗しました"
 fi
 
 # エラー処理（テスト失敗時のみ）


### PR DESCRIPTION
## Summary
- generate a basic test log from detailed-results if not produced
- add script to create fallback markdown log

## Testing
- `npm run test:unit` *(fails: npm warns unknown env config)*