### PR TITLE
Fix formatters and add fund utils tests

### DIFF
--- a/__tests__/unit/utils/fundUtils.test.js
+++ b/__tests__/unit/utils/fundUtils.test.js
@@ -1,0 +1,27 @@
+import { guessFundType, estimateAnnualFee, estimateDividendYield } from '@/utils/fundUtils';
+
+describe('fundUtils', () => {
+  describe('guessFundType', () => {
+    it('returns US ETF for known ETF ticker', () => {
+      expect(guessFundType('SPY')).toBe('ETF（米国）');
+    });
+
+    it('returns JP ETF for Japanese ticker', () => {
+      expect(guessFundType('1306.T', 'TOPIX ETF')).toBe('ETF（日本）');
+    });
+  });
+
+  describe('estimateAnnualFee', () => {
+    it('uses specific fee for known ticker', () => {
+      const result = estimateAnnualFee('VOO');
+      expect(result).toEqual(expect.objectContaining({ fee: 0.03, isEstimated: false }));
+    });
+  });
+
+  describe('estimateDividendYield', () => {
+    it('returns average yield for US ETF', () => {
+      const result = estimateDividendYield('VTI');
+      expect(result).toEqual(expect.objectContaining({ yield: 1.5, hasDividend: true }));
+    });
+  });
+});

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -23,18 +23,14 @@
 export const formatCurrency = (amount, currency = 'JPY') => {
   if (typeof amount !== 'number' || Number.isNaN(amount)) return 'N/A';
 
-  const formatter = new Intl.NumberFormat(currency === 'JPY' ? 'ja-JP' : 'en-US', {
+  const formatter = new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency,
     minimumFractionDigits: currency === 'JPY' ? 0 : 2,
     maximumFractionDigits: currency === 'JPY' ? 0 : 2
   });
 
-  let result = formatter.format(amount);
-  if (currency === 'JPY') {
-    result = result.replace('￥', '¥');
-  }
-  return result;
+  return formatter.format(amount);
 };
   
   /**
@@ -46,10 +42,8 @@ export const formatCurrency = (amount, currency = 'JPY') => {
 export const formatPercent = (value, fractionDigits = 2) => {
   if (typeof value !== 'number' || Number.isNaN(value)) return 'N/A';
 
-  if (Number.isInteger(value) && fractionDigits === 2) {
-    return `${value}%`;
-  }
-  return `${value.toFixed(fractionDigits)}%`;
+  const formatted = value.toFixed(fractionDigits);
+  return `${formatted.endsWith('.00') ? parseInt(formatted, 10) : formatted}%`;
 };
   
   /**


### PR DESCRIPTION
## Summary
- fix currency and percent formatting logic
- add tests for fund utilities

## Testing
- `npm run test:all` *(fails: EHOSTUNREACH)*