### PR TITLE
Fix fetchWithRetry delay handling and add authFetch tests

### DIFF
--- a/document/structure-and-modules.md
+++ b/document/structure-and-modules.md
@@ -78,7 +78,7 @@
 - `src/utils/apiUtils.js`
   - `createApiClient(withAuth)` – Axios クライアントを生成。
   - `marketDataClient` / `authApiClient` – 上記クライアントのインスタンス。
-  - `fetchWithRetry(endpoint, params, timeout, maxRetries)` – リトライ付きの GET リクエスト。レスポンスデータを返す。
+  - `fetchWithRetry(endpoint, params, timeout, maxRetries, delayFn)` – リトライ付きの GET リクエスト。`delayFn` は待機処理をカスタマイズするための任意パラメータ。
   - `authFetch(endpoint, method, data, config)` – 認証付きリクエストを実行しレスポンスデータを返す。
   - `formatErrorResponse(error, ticker)` – エラーデータを整形して返す。
   - `generateFallbackData(ticker)` – 取得失敗時のフォールバックデータを作成。

--- a/src/utils/apiUtils.js
+++ b/src/utils/apiUtils.js
@@ -153,7 +153,16 @@ export const marketDataClient = createApiClient(false);
 export const authApiClient = createApiClient(true);
 
 // リトライ付きフェッチ関数
-export const fetchWithRetry = async (endpoint, params = {}, timeout = TIMEOUT.DEFAULT, maxRetries = RETRY.MAX_ATTEMPTS) => {
+// 遅延用のヘルパー関数（テストでモック可能）
+export const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+export const fetchWithRetry = async (
+  endpoint,
+  params = {},
+  timeout = TIMEOUT.DEFAULT,
+  maxRetries = RETRY.MAX_ATTEMPTS,
+  delayFn = wait
+) => {
   let retries = 0;
   
   while (retries <= maxRetries) {
@@ -181,7 +190,7 @@ export const fetchWithRetry = async (endpoint, params = {}, timeout = TIMEOUT.DE
       // リトライ前に遅延を入れる（指数バックオフ+ジッター）
       const delay = RETRY.INITIAL_DELAY * Math.pow(RETRY.BACKOFF_FACTOR, retries) * (0.9 + Math.random() * 0.2);
       console.log(`リトライ待機: ${Math.round(delay)}ms`);
-      await new Promise(resolve => setTimeout(resolve, delay));
+      await delayFn(delay);
       
       // リトライカウントを増やす
       retries++;


### PR DESCRIPTION
## Summary
- inject delay function into `fetchWithRetry` for easier testing
- document new optional parameter in structure overview
- update `apiUtils` unit tests to use the new delay hook
- add unit tests for `authFetch`

## Testing
- `npm run test:unit` *(fails: react-scripts not found)*