### PR TITLE
Add tests for common components

### DIFF
--- a/__tests__/unit/components/DataSourceBadge.test.js
+++ b/__tests__/unit/components/DataSourceBadge.test.js
@@ -1,0 +1,47 @@
+/**
+ * ファイルパス: __test__/unit/components/DataSourceBadge.test.js
+ *
+ * DataSourceBadgeコンポーネントの単体テスト
+ * データソース表示とアイコン表示オプションをテスト
+ *
+ * @author プロジェクトチーム
+ * @created 2025-05-21
+ */
+
+// テスト対象モジュールのインポート
+import DataSourceBadge from '@/components/common/DataSourceBadge';
+
+// テスト用ライブラリ
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+describe('DataSourceBadgeコンポーネント', () => {
+  it('既知のソースでは適切なテキストとアイコンを表示する', () => {
+    render(<DataSourceBadge source="Alpaca" />);
+
+    const badge = screen.getByText('Alpaca');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent('Alpaca');
+    // アイコンが表示されていることを確認
+    expect(badge.querySelector('span')).toBeInTheDocument();
+  });
+
+  it('showIcon=falseの場合はアイコンが非表示になる', () => {
+    render(<DataSourceBadge source="Yahoo Finance" showIcon={false} />);
+
+    // 表示テキストは短縮形になっている
+    expect(screen.getByText('YFinance')).toBeInTheDocument();
+    const badge = screen.getByText('YFinance');
+    // 子要素にアイコンがないことを確認
+    expect(badge.querySelector('span')).not.toBeInTheDocument();
+  });
+
+  it('未知のソースではデフォルト表示を行う', () => {
+    render(<DataSourceBadge source="Unknown" />);
+
+    const badge = screen.getByText('Unknown');
+    expect(badge).toBeInTheDocument();
+    // タイトル属性がデフォルトの説明になっているか確認
+    expect(badge).toHaveAttribute('title', '不明なデータソース');
+  });
+});

--- a/__tests__/unit/components/ErrorBoundary.test.js
+++ b/__tests__/unit/components/ErrorBoundary.test.js
@@ -1,0 +1,40 @@
+/**
+ * ファイルパス: __test__/unit/components/ErrorBoundary.test.js
+ *
+ * ErrorBoundaryコンポーネントの単体テスト
+ * 子コンポーネントで発生した例外のハンドリングをテスト
+ *
+ * @author プロジェクトチーム
+ * @created 2025-05-21
+ */
+
+import React from 'react';
+import ErrorBoundary from '@/components/common/ErrorBoundary';
+import { render, screen } from '@testing-library/react';
+
+// エラーを投げるテスト用コンポーネント
+const BrokenComponent = () => {
+  throw new Error('Test error');
+};
+
+describe('ErrorBoundaryコンポーネント', () => {
+  it('子コンポーネントでエラーが発生した場合にフォールバックUIを表示する', () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <ErrorBoundary>
+        <BrokenComponent />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('コンポーネントの読み込み中にエラーが発生しました')).toBeInTheDocument();
+    consoleSpy.mockRestore();
+  });
+
+  it('エラーが発生しない場合は子要素を表示する', () => {
+    render(
+      <ErrorBoundary>
+        <div>正常表示</div>
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('正常表示')).toBeInTheDocument();
+  });
+});

--- a/__tests__/unit/components/ToastNotification.test.js
+++ b/__tests__/unit/components/ToastNotification.test.js
@@ -1,0 +1,48 @@
+/**
+ * ファイルパス: __test__/unit/components/ToastNotification.test.js
+ *
+ * ToastNotificationコンポーネントの単体テスト
+ * メッセージ表示、自動消去、手動閉じる動作をテスト
+ *
+ * @author プロジェクトチーム
+ * @created 2025-05-21
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ToastNotification from '@/components/common/ToastNotification';
+
+describe('ToastNotificationコンポーネント', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('指定されたメッセージを表示し、時間経過後に自動で閉じる', () => {
+    render(<ToastNotification message="Hello" duration={1000} />);
+
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+
+    // 時間を進めて非表示になることを確認
+    jest.advanceTimersByTime(1000);
+
+    expect(screen.queryByText('Hello')).not.toBeInTheDocument();
+  });
+
+  it('閉じるボタンで手動で閉じることができる', async () => {
+    const handleClose = jest.fn();
+    render(<ToastNotification message="Bye" onClose={handleClose} />);
+
+    expect(screen.getByText('Bye')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(screen.queryByText('Bye')).not.toBeInTheDocument();
+    expect(handleClose).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- increase test coverage by adding tests for DataSourceBadge, ErrorBoundary and ToastNotification components

## Testing
- `npm run test:all` *(fails: connect EHOSTUNREACH 172.25.0.3:8080)*