### PR TITLE
Add tests for settings components

### DIFF
--- a/__tests__/unit/components/AiPromptSettings.test.js
+++ b/__tests__/unit/components/AiPromptSettings.test.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AiPromptSettings from '@/components/settings/AiPromptSettings';
+
+jest.mock('@/hooks/usePortfolioContext', () => ({
+  usePortfolioContext: jest.fn()
+}));
+
+const { usePortfolioContext } = require('@/hooks/usePortfolioContext');
+
+const DEFAULT_SUBSTRING = 'あなたは投資分析に特化した AI アシスタントです';
+
+describe('AiPromptSettings', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders default template when no template is provided', () => {
+    usePortfolioContext.mockReturnValue({
+      aiPromptTemplate: null,
+      updateAiPromptTemplate: jest.fn()
+    });
+
+    render(<AiPromptSettings />);
+
+    const textarea = screen.getByRole('textbox');
+    expect(textarea.value).toContain(DEFAULT_SUBSTRING);
+  });
+
+  it('allows editing and saving template', async () => {
+    const updateAiPromptTemplate = jest.fn();
+    usePortfolioContext.mockReturnValue({
+      aiPromptTemplate: 'Initial Template',
+      updateAiPromptTemplate
+    });
+
+    render(<AiPromptSettings />);
+
+    const textarea = screen.getByRole('textbox');
+    expect(textarea.value).toBe('Initial Template');
+
+    await userEvent.clear(textarea);
+    await userEvent.type(textarea, 'New Template');
+
+    const saveButton = screen.getByText('保存');
+    await userEvent.click(saveButton);
+
+    expect(updateAiPromptTemplate).toHaveBeenCalledWith('New Template');
+    expect(screen.getByText('保存しました')).toBeInTheDocument();
+  });
+
+  it('reset button restores default template', async () => {
+    usePortfolioContext.mockReturnValue({
+      aiPromptTemplate: 'Custom Template',
+      updateAiPromptTemplate: jest.fn()
+    });
+
+    render(<AiPromptSettings />);
+
+    const textarea = screen.getByRole('textbox');
+    expect(textarea.value).toBe('Custom Template');
+
+    const resetButton = screen.getByText('デフォルトに戻す');
+    await userEvent.click(resetButton);
+
+    expect(textarea.value).toContain(DEFAULT_SUBSTRING);
+  });
+});

--- a/__tests__/unit/components/TickerSearch.test.js
+++ b/__tests__/unit/components/TickerSearch.test.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TickerSearch from '@/components/settings/TickerSearch';
+
+jest.mock('@/hooks/usePortfolioContext', () => ({
+  usePortfolioContext: jest.fn()
+}));
+
+const { usePortfolioContext } = require('@/hooks/usePortfolioContext');
+
+describe('TickerSearch', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('validates empty input', async () => {
+    usePortfolioContext.mockReturnValue({ addTicker: jest.fn() });
+    render(<TickerSearch />);
+
+    await userEvent.click(screen.getByRole('button', { name: '追加' }));
+
+    expect(screen.getByText('ティッカーシンボルを入力してください')).toBeInTheDocument();
+  });
+
+  it('validates ticker format', async () => {
+    usePortfolioContext.mockReturnValue({ addTicker: jest.fn() });
+    render(<TickerSearch />);
+
+    const input = screen.getByPlaceholderText('例: AAPL, 7203.T');
+    await userEvent.type(input, 'invalid ticker');
+    await userEvent.click(screen.getByRole('button', { name: '追加' }));
+
+    expect(screen.getByText('無効なティッカーシンボル形式です')).toBeInTheDocument();
+  });
+
+  it('calls addTicker and clears input on success', async () => {
+    const addTicker = jest.fn().mockResolvedValue({ success: true, message: 'ok' });
+    usePortfolioContext.mockReturnValue({ addTicker });
+    render(<TickerSearch />);
+
+    const input = screen.getByPlaceholderText('例: AAPL, 7203.T');
+    await userEvent.type(input, 'aapl');
+    await userEvent.click(screen.getByRole('button', { name: '追加' }));
+
+    expect(addTicker).toHaveBeenCalledWith('AAPL');
+    expect(screen.getByText('ok')).toBeInTheDocument();
+    expect(input.value).toBe('');
+  });
+});

--- a/__tests__/unit/utils/fundUtils.test.js
+++ b/__tests__/unit/utils/fundUtils.test.js
@@ -25,3 +25,43 @@ describe('fundUtils', () => {
     });
   });
 });
+
+import { extractFundInfo } from '@/utils/fundUtils';
+
+describe('extractFundInfo', () => {
+  it('detects region, currency and dividend info for US ETF', () => {
+    const info = extractFundInfo('VOO', 'Vanguard S&P 500 ETF');
+    expect(info).toEqual(
+      expect.objectContaining({
+        region: '米国',
+        currency: 'USD',
+        hasDividend: true,
+        fundType: 'ETF（米国）',
+        isStock: false
+      })
+    );
+  });
+
+  it('detects stock with no dividend info for JP stock', () => {
+    const info = extractFundInfo('7203.T', 'トヨタ自動車');
+    expect(info).toEqual(
+      expect.objectContaining({
+        region: '日本',
+        currency: 'JPY',
+        fundType: '個別株',
+        isStock: true
+      })
+    );
+  });
+
+  it('classifies REIT ETF correctly', () => {
+    const info = extractFundInfo('VNQ', 'Vanguard Real Estate ETF');
+    expect(info).toEqual(
+      expect.objectContaining({
+        region: '米国',
+        fundType: 'REIT（米国）',
+        hasDividend: true
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `AiPromptSettings` and `TickerSearch` components
- extend `fundUtils` tests with `extractFundInfo` cases

## Testing
- `npm run test:all` *(fails: connect EHOSTUNREACH)*