### PR TITLE
Add hook tests

### DIFF
--- a/__tests__/unit/hooks/useAuth.test.js
+++ b/__tests__/unit/hooks/useAuth.test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { AuthProvider } from '@/context/AuthContext';
+import useAuth from '@/hooks/useAuth';
+
+// AuthProvider 内で使用されていない場合にエラーを投げることを確認
+it('throws error when used outside AuthProvider', () => {
+  const { result } = renderHook(() => useAuth());
+  expect(result.error).toEqual(new Error('useAuth must be used within an AuthProvider'));
+});
+
+// AuthProvider でラップした場合にコンテキスト値を取得できることを確認
+it('provides context values when wrapped with AuthProvider', () => {
+  const wrapper = ({ children }) => <AuthProvider>{children}</AuthProvider>;
+  const { result } = renderHook(() => useAuth(), { wrapper });
+
+  expect(result.current).toHaveProperty('loginWithGoogle');
+  expect(result.current).toHaveProperty('logout');
+  expect(result.current).toHaveProperty('isAuthenticated');
+});

--- a/__tests__/unit/hooks/useGoogleDrive.test.js
+++ b/__tests__/unit/hooks/useGoogleDrive.test.js
@@ -1,0 +1,72 @@
+import { renderHook, act } from '@testing-library/react';
+import { useGoogleDrive } from '@/hooks/useGoogleDrive';
+import { useAuth } from '@/hooks/useAuth';
+import { authApiClient } from '@/utils/apiUtils';
+import { getApiEndpoint } from '@/utils/envUtils';
+
+jest.mock('@/hooks/useAuth');
+jest.mock('@/utils/apiUtils');
+jest.mock('@/utils/envUtils');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getApiEndpoint.mockImplementation((path) => `/api/${path}`);
+});
+
+describe('useGoogleDrive', () => {
+  it('returns error when unauthenticated', async () => {
+    useAuth.mockReturnValue({ isAuthenticated: false });
+    const { result } = renderHook(() => useGoogleDrive());
+
+    let files;
+    await act(async () => {
+      files = await result.current.listFiles();
+    });
+
+    expect(files).toBeNull();
+    expect(result.current.error).toBe('認証が必要です');
+  });
+
+  it('listFiles calls API when authenticated', async () => {
+    useAuth.mockReturnValue({ isAuthenticated: true });
+    authApiClient.get = jest.fn().mockResolvedValue({ data: { success: true, files: ['file1'] } });
+
+    const { result } = renderHook(() => useGoogleDrive());
+    let files;
+    await act(async () => {
+      files = await result.current.listFiles();
+    });
+
+    expect(authApiClient.get).toHaveBeenCalledWith('/api/drive/files');
+    expect(files).toEqual(['file1']);
+  });
+
+  it('saveFile posts data to API', async () => {
+    useAuth.mockReturnValue({ isAuthenticated: true });
+    authApiClient.post = jest.fn().mockResolvedValue({ data: { success: true, file: 'id' } });
+
+    const { result } = renderHook(() => useGoogleDrive());
+
+    let file;
+    await act(async () => {
+      file = await result.current.saveFile({});
+    });
+
+    expect(authApiClient.post).toHaveBeenCalledWith('/api/drive/save', { portfolioData: {} });
+    expect(file).toBe('id');
+  });
+
+  it('loadFile gets data from API', async () => {
+    useAuth.mockReturnValue({ isAuthenticated: true });
+    authApiClient.get = jest.fn().mockResolvedValue({ data: { success: true, data: { foo: 'bar' } } });
+
+    const { result } = renderHook(() => useGoogleDrive());
+    let data;
+    await act(async () => {
+      data = await result.current.loadFile('123');
+    });
+
+    expect(authApiClient.get).toHaveBeenCalledWith('/api/drive/load', { params: { fileId: '123' } });
+    expect(data).toEqual({ foo: 'bar' });
+  });
+});

--- a/__tests__/unit/hooks/usePortfolioContext.test.js
+++ b/__tests__/unit/hooks/usePortfolioContext.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { PortfolioProvider } from '@/context/PortfolioContext';
+import usePortfolioContext from '@/hooks/usePortfolioContext';
+
+// Provider なしで使用した場合にエラーが投げられるか確認
+it('throws error when used outside PortfolioProvider', () => {
+  const { result } = renderHook(() => usePortfolioContext());
+  expect(result.error).toEqual(new Error('usePortfolioContext must be used within a PortfolioProvider'));
+});
+
+// 通常の利用: baseCurrency の初期値と toggleCurrency の動作を検証
+it('provides context values and toggleCurrency works', () => {
+  const wrapper = ({ children }) => <PortfolioProvider>{children}</PortfolioProvider>;
+  const { result } = renderHook(() => usePortfolioContext(), { wrapper });
+
+  expect(result.current.baseCurrency).toBe('JPY');
+
+  act(() => {
+    result.current.toggleCurrency();
+  });
+
+  expect(result.current.baseCurrency).toBe('USD');
+});


### PR DESCRIPTION
## Summary
- add tests for `useAuth` and `usePortfolioContext`
- cover Google Drive hook API behavior

## Testing
- `npm run test:all` *(fails: unable to reach npm registry)*