### PR TITLE
Fix hook tests and update App test

### DIFF
--- a/__tests__/unit/hooks/useAuth.test.js
+++ b/__tests__/unit/hooks/useAuth.test.js
@@ -5,8 +5,9 @@ import useAuth from '@/hooks/useAuth';
 
 // AuthProvider 内で使用されていない場合にエラーを投げることを確認
 it('throws error when used outside AuthProvider', () => {
-  const { result } = renderHook(() => useAuth());
-  expect(result.error).toEqual(new Error('useAuth must be used within an AuthProvider'));
+  expect(() => renderHook(() => useAuth())).toThrow(
+    'useAuth must be used within an AuthProvider'
+  );
 });
 
 // AuthProvider でラップした場合にコンテキスト値を取得できることを確認

--- a/__tests__/unit/hooks/usePortfolioContext.test.js
+++ b/__tests__/unit/hooks/usePortfolioContext.test.js
@@ -5,8 +5,9 @@ import usePortfolioContext from '@/hooks/usePortfolioContext';
 
 // Provider なしで使用した場合にエラーが投げられるか確認
 it('throws error when used outside PortfolioProvider', () => {
-  const { result } = renderHook(() => usePortfolioContext());
-  expect(result.error).toEqual(new Error('usePortfolioContext must be used within a PortfolioProvider'));
+  expect(() => renderHook(() => usePortfolioContext())).toThrow(
+    'usePortfolioContext must be used within a PortfolioProvider'
+  );
 });
 
 // 通常の利用: baseCurrency の初期値と toggleCurrency の動作を検証

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -17,9 +17,23 @@
 
 import { render, screen } from '@testing-library/react';
 import App from './App';
+import * as authHook from './hooks/useAuth';
+import * as portfolioHook from './hooks/usePortfolioContext';
 
-test('renders learn react link', () => {
+jest.mock('./hooks/useAuth');
+jest.mock('./hooks/usePortfolioContext');
+
+test('renders header title', () => {
+  authHook.useAuth.mockReturnValue({ isAuthenticated: false });
+  portfolioHook.usePortfolioContext.mockReturnValue({
+    baseCurrency: 'JPY',
+    toggleCurrency: jest.fn(),
+    refreshMarketPrices: jest.fn(),
+    lastUpdated: null,
+    isLoading: false,
+    currentAssets: []
+  });
+
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(screen.getByText('ポートフォリオマネージャー')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- fix tests for `useAuth` and `usePortfolioContext` to assert thrown errors
- mock hooks in `App.test.js` and check the header title

## Testing
- `npm run test:unit` *(fails: ENOENT or network error)*