### PR TITLE
Fix hook tests and add DataStatusBar coverage

### DIFF
--- a/__tests__/unit/components/DataStatusBar.test.js
+++ b/__tests__/unit/components/DataStatusBar.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DataStatusBar from '@/components/layout/DataStatusBar';
+
+jest.mock('@/hooks/usePortfolioContext', () => ({
+  usePortfolioContext: jest.fn()
+}));
+
+const { usePortfolioContext } = require('@/hooks/usePortfolioContext');
+
+describe('DataStatusBar', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows warning when data is not updated', () => {
+    usePortfolioContext.mockReturnValue({
+      lastUpdated: null,
+      exchangeRate: null,
+      baseCurrency: 'JPY',
+      refreshMarketPrices: jest.fn(),
+      isLoading: false
+    });
+
+    render(<DataStatusBar />);
+
+    expect(screen.getByText('未取得')).toBeInTheDocument();
+    expect(screen.getByText('データの更新が必要です')).toBeInTheDocument();
+  });
+
+  it('calls refreshMarketPrices on button click', async () => {
+    const refreshMarketPrices = jest.fn();
+    usePortfolioContext.mockReturnValue({
+      lastUpdated: new Date().toISOString(),
+      exchangeRate: { rate: 150, source: 'Test' },
+      baseCurrency: 'JPY',
+      refreshMarketPrices,
+      isLoading: false
+    });
+
+    render(<DataStatusBar />);
+
+    await userEvent.click(screen.getByText('更新'));
+    expect(refreshMarketPrices).toHaveBeenCalled();
+  });
+
+  it('shows loading state', () => {
+    usePortfolioContext.mockReturnValue({
+      lastUpdated: new Date().toISOString(),
+      exchangeRate: { rate: 150, source: 'Test' },
+      baseCurrency: 'JPY',
+      refreshMarketPrices: jest.fn(),
+      isLoading: true
+    });
+
+    render(<DataStatusBar />);
+
+    expect(screen.getByText('更新中...')).toBeInTheDocument();
+  });
+});

--- a/__tests__/unit/hooks/useAuth.test.js
+++ b/__tests__/unit/hooks/useAuth.test.js
@@ -5,8 +5,9 @@ import useAuth from '@/hooks/useAuth';
 
 // AuthProvider 内で使用されていない場合にエラーを投げることを確認
 it('throws error when used outside AuthProvider', () => {
-  expect(() => renderHook(() => useAuth())).toThrow(
-    'useAuth must be used within an AuthProvider'
+  const { result } = renderHook(() => useAuth());
+  expect(result.error).toEqual(
+    new Error('useAuth must be used within an AuthProvider')
   );
 });
 

--- a/__tests__/unit/hooks/usePortfolioContext.test.js
+++ b/__tests__/unit/hooks/usePortfolioContext.test.js
@@ -5,8 +5,9 @@ import usePortfolioContext from '@/hooks/usePortfolioContext';
 
 // Provider なしで使用した場合にエラーが投げられるか確認
 it('throws error when used outside PortfolioProvider', () => {
-  expect(() => renderHook(() => usePortfolioContext())).toThrow(
-    'usePortfolioContext must be used within a PortfolioProvider'
+  const { result } = renderHook(() => usePortfolioContext());
+  expect(result.error).toEqual(
+    new Error('usePortfolioContext must be used within a PortfolioProvider')
   );
 });
 


### PR DESCRIPTION
## Summary
- fix hook error checks in `useAuth` and `usePortfolioContext` tests
- add new tests for `DataStatusBar` component

## Testing
- `npm run test:all` *(fails: connect EHOSTUNREACH)*