### PR TITLE
Fix hook error tests

### DIFF
--- a/__tests__/unit/hooks/useAuth.test.js
+++ b/__tests__/unit/hooks/useAuth.test.js
@@ -5,8 +5,7 @@ import useAuth from '@/hooks/useAuth';
 
 // AuthProvider 内で使用されていない場合にエラーを投げることを確認
 it('throws error when used outside AuthProvider', () => {
-  const { result } = renderHook(() => useAuth());
-  expect(result.error).toEqual(
+  expect(() => renderHook(() => useAuth())).toThrow(
     new Error('useAuth must be used within an AuthProvider')
   );
 });

--- a/__tests__/unit/hooks/usePortfolioContext.test.js
+++ b/__tests__/unit/hooks/usePortfolioContext.test.js
@@ -5,8 +5,7 @@ import usePortfolioContext from '@/hooks/usePortfolioContext';
 
 // Provider なしで使用した場合にエラーが投げられるか確認
 it('throws error when used outside PortfolioProvider', () => {
-  const { result } = renderHook(() => usePortfolioContext());
-  expect(result.error).toEqual(
+  expect(() => renderHook(() => usePortfolioContext())).toThrow(
     new Error('usePortfolioContext must be used within a PortfolioProvider')
   );
 });


### PR DESCRIPTION
## Summary
- fix tests for `useAuth` and `usePortfolioContext` hooks
- hooks now checked via `toThrow`

## Testing
- `npm run test:unit` *(fails: missing dependencies)*