### PR TITLE
Fix unit tests and adjust URL mock

### DIFF
--- a/__tests__/unit/components/AiPromptSettings.test.js
+++ b/__tests__/unit/components/AiPromptSettings.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import AiPromptSettings from '@/components/settings/AiPromptSettings';
 
@@ -40,15 +40,16 @@ describe('AiPromptSettings', () => {
     const textarea = screen.getByRole('textbox');
     expect(textarea.value).toBe('Initial Template');
 
-    await userEvent.clear(textarea);
+    const user = userEvent.setup();
+    await user.clear(textarea);
     expect(textarea.value).toBe('');
-    await userEvent.type(textarea, 'New Template');
+    await user.type(textarea, 'New Template');
 
     const saveButton = screen.getByText('保存');
-    await userEvent.click(saveButton);
+    await user.click(saveButton);
 
     expect(updateAiPromptTemplate).toHaveBeenCalledWith('New Template');
-    expect(screen.getByText('保存しました')).toBeInTheDocument();
+    expect(await screen.findByText('保存しました')).toBeInTheDocument();
   });
 
   it('reset button restores default template', async () => {
@@ -63,8 +64,11 @@ describe('AiPromptSettings', () => {
     expect(textarea.value).toBe('Custom Template');
 
     const resetButton = screen.getByText('デフォルトに戻す');
-    await userEvent.click(resetButton);
+    const user = userEvent.setup();
+    await user.click(resetButton);
 
-    expect(textarea.value).toContain(DEFAULT_SUBSTRING);
+    await waitFor(() => {
+      expect(textarea.value).toContain(DEFAULT_SUBSTRING);
+    });
   });
 });

--- a/__tests__/unit/components/TickerSearch.test.js
+++ b/__tests__/unit/components/TickerSearch.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TickerSearch from '@/components/settings/TickerSearch';
 
@@ -18,9 +18,10 @@ describe('TickerSearch', () => {
     usePortfolioContext.mockReturnValue({ addTicker: jest.fn() });
     render(<TickerSearch />);
 
-    await userEvent.click(screen.getByRole('button', { name: '追加' }));
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: '追加' }));
 
-    expect(screen.getByText('ティッカーシンボルを入力してください')).toBeInTheDocument();
+    expect(await screen.findByText('ティッカーシンボルを入力してください')).toBeInTheDocument();
   });
 
   it('validates ticker format', async () => {
@@ -28,10 +29,11 @@ describe('TickerSearch', () => {
     render(<TickerSearch />);
 
     const input = screen.getByPlaceholderText('例: AAPL, 7203.T');
-    await userEvent.type(input, 'invalid ticker');
-    await userEvent.click(screen.getByRole('button', { name: '追加' }));
+    const user = userEvent.setup();
+    await user.type(input, 'invalid ticker');
+    await user.click(screen.getByRole('button', { name: '追加' }));
 
-    expect(screen.getByText('無効なティッカーシンボル形式です')).toBeInTheDocument();
+    expect(await screen.findByText('無効なティッカーシンボル形式です')).toBeInTheDocument();
   });
 
   it('calls addTicker and clears input on success', async () => {
@@ -40,8 +42,9 @@ describe('TickerSearch', () => {
     render(<TickerSearch />);
 
     const input = screen.getByPlaceholderText('例: AAPL, 7203.T');
-    await userEvent.type(input, 'aapl');
-    await userEvent.click(screen.getByRole('button', { name: '追加' }));
+    const user = userEvent.setup();
+    await user.type(input, 'aapl');
+    await user.click(screen.getByRole('button', { name: '追加' }));
 
     expect(addTicker).toHaveBeenCalledWith('AAPL');
     expect(await screen.findByText('ok')).toBeInTheDocument();

--- a/__tests__/unit/components/ToastNotification.test.js
+++ b/__tests__/unit/components/ToastNotification.test.js
@@ -11,6 +11,7 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { act } from 'react-dom/test-utils';
 import ToastNotification from '@/components/common/ToastNotification';
 
 describe('ToastNotificationコンポーネント', () => {
@@ -28,7 +29,9 @@ describe('ToastNotificationコンポーネント', () => {
 
     expect(screen.getByText('Hello')).toBeInTheDocument();
 
-    jest.advanceTimersByTime(1000);
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
 
     await waitFor(() => {
       expect(screen.queryByText('Hello')).not.toBeInTheDocument();
@@ -41,7 +44,8 @@ describe('ToastNotificationコンポーネント', () => {
 
     expect(screen.getByText('Bye')).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button'));
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button'));
 
     await waitFor(() => {
       expect(screen.queryByText('Bye')).not.toBeInTheDocument();

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -160,15 +160,19 @@ window.matchMedia = jest.fn().mockImplementation(query => ({
   }),
 }));
 
-// URL モック
-global.URL = {
-  createObjectURL: jest.fn((blob) => {
+// URL モック - コンストラクタ機能を保持しつつ createObjectURL などを上書き
+const OriginalURL = global.URL;
+global.URL = class MockURL extends OriginalURL {
+  constructor(url, base) {
+    super(url, base);
+  }
+  static createObjectURL(blob) {
     debugLog('URL.createObjectURL called', { type: blob?.type, size: blob?.size });
     return 'blob:mock-url';
-  }),
-  revokeObjectURL: jest.fn((url) => {
+  }
+  static revokeObjectURL(url) {
     debugLog('URL.revokeObjectURL called', { url });
-  })
+  }
 };
 
 // File API モック

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -23,7 +23,7 @@ import * as portfolioHook from './hooks/usePortfolioContext';
 jest.mock('./hooks/useAuth');
 jest.mock('./hooks/usePortfolioContext');
 
-test('renders header title', () => {
+test('renders header title', async () => {
   authHook.useAuth.mockReturnValue({ isAuthenticated: false });
   portfolioHook.usePortfolioContext.mockReturnValue({
     baseCurrency: 'JPY',
@@ -35,5 +35,5 @@ test('renders header title', () => {
   });
 
   render(<App />);
-  expect(screen.getByText('ポートフォリオマネージャー')).toBeInTheDocument();
+  expect(await screen.findByText('ポートフォリオマネージャー')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- improve URL mock to preserve constructor
- fix ToastNotification tests using act and userEvent
- update AiPromptSettings and TickerSearch tests to await DOM updates
- ensure App test waits for header rendering

## Testing
- `npm run test:unit` *(fails: EHOSTUNREACH - dependencies not installed)*