### PR TITLE
Add tests for connector and token utilities

### DIFF
--- a/__tests__/unit/components/ContextConnector.test.js
+++ b/__tests__/unit/components/ContextConnector.test.js
@@ -1,0 +1,44 @@
+/**
+ * ファイルパス: __tests__/unit/components/ContextConnector.test.js
+ *
+ * ContextConnector コンポーネントの単体テスト
+ * AuthContext と PortfolioContext の接続処理を検証
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import ContextConnector from '@/components/common/ContextConnector';
+
+jest.mock('@/hooks/useAuth', () => ({ useAuth: jest.fn() }));
+jest.mock('@/hooks/usePortfolioContext', () => ({ usePortfolioContext: jest.fn() }));
+
+const { useAuth } = require('@/hooks/useAuth');
+const { usePortfolioContext } = require('@/hooks/usePortfolioContext');
+
+describe('ContextConnector', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls setPortfolioContextRef with portfolio context', () => {
+    const setRef = jest.fn();
+    const portfolio = { foo: 'bar' };
+    useAuth.mockReturnValue({ setPortfolioContextRef: setRef });
+    usePortfolioContext.mockReturnValue(portfolio);
+
+    render(<ContextConnector />);
+
+    expect(setRef).toHaveBeenCalledWith(portfolio);
+  });
+
+  it('does nothing when setPortfolioContextRef is undefined', () => {
+    const portfolio = { foo: 'bar' };
+    useAuth.mockReturnValue({});
+    usePortfolioContext.mockReturnValue(portfolio);
+
+    render(<ContextConnector />);
+
+    expect(useAuth).toHaveBeenCalled();
+    expect(usePortfolioContext).toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/utils/apiUtils.token.test.js
+++ b/__tests__/unit/utils/apiUtils.token.test.js
@@ -1,0 +1,43 @@
+/**
+ * ファイルパス: __tests__/unit/utils/apiUtils.token.test.js
+ *
+ * 認証トークンユーティリティの単体テスト
+ * setAuthToken, getAuthToken, clearAuthToken の動作を検証
+ */
+
+import axios from 'axios';
+
+jest.mock('axios');
+
+const loadModule = () => require('@/utils/apiUtils');
+
+describe('auth token utils', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    axios.create.mockReturnValue({ interceptors: { request: { use: jest.fn() }, response: { use: jest.fn() } } });
+  });
+
+  it('stores and retrieves token', () => {
+    const { setAuthToken, getAuthToken } = loadModule();
+    setAuthToken('token123');
+    expect(getAuthToken()).toBe('token123');
+  });
+
+  it('clears token', () => {
+    const { setAuthToken, getAuthToken, clearAuthToken } = loadModule();
+    setAuthToken('token123');
+    clearAuthToken();
+    expect(getAuthToken()).toBeNull();
+  });
+
+  it('request interceptor attaches Authorization header', () => {
+    const requestUse = jest.fn();
+    axios.create.mockReturnValue({ interceptors: { request: { use: requestUse }, response: { use: jest.fn() } } });
+    const { createApiClient, setAuthToken } = loadModule();
+    createApiClient(true);
+    const interceptor = requestUse.mock.calls[0][0];
+    setAuthToken('abcd');
+    const config = interceptor({ headers: {}, url: '/api', method: 'get' });
+    expect(config.headers.Authorization).toBe('Bearer abcd');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for ContextConnector component
- add unit tests for auth token helpers in apiUtils

## Testing
- `npm run test:all` *(fails: request to registry.npmjs.org failed)*