### PR TITLE
Fix tests for toast notifications and api utils

### DIFF
--- a/__tests__/unit/components/ToastNotification.test.js
+++ b/__tests__/unit/components/ToastNotification.test.js
@@ -31,6 +31,7 @@ describe('ToastNotificationコンポーネント', () => {
 
     act(() => {
       jest.advanceTimersByTime(1000);
+      jest.runOnlyPendingTimers();
     });
 
     await waitFor(() => {
@@ -46,6 +47,10 @@ describe('ToastNotificationコンポーネント', () => {
 
     const user = userEvent.setup();
     await user.click(screen.getByRole('button'));
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
 
     await waitFor(() => {
       expect(screen.queryByText('Bye')).not.toBeInTheDocument();

--- a/__tests__/unit/utils/apiUtils.token.test.js
+++ b/__tests__/unit/utils/apiUtils.token.test.js
@@ -34,9 +34,10 @@ describe('auth token utils', () => {
     const requestUse = jest.fn();
     axios.create.mockReturnValue({ interceptors: { request: { use: requestUse }, response: { use: jest.fn() } } });
     const { createApiClient, setAuthToken } = loadModule();
-    createApiClient(true);
-    const interceptor = requestUse.mock.calls[0][0];
     setAuthToken('abcd');
+    createApiClient(true);
+    expect(requestUse).toHaveBeenCalled();
+    const interceptor = requestUse.mock.calls[0][0];
     const config = interceptor({ headers: {}, url: '/api', method: 'get' });
     expect(config.headers.Authorization).toBe('Bearer abcd');
   });


### PR DESCRIPTION
## Summary
- run pending timers in ToastNotification tests
- ensure request interceptor test verifies registration

## Testing
- `npm install --ignore-scripts` *(fails: ENOENT)*
- `./script/run-tests.sh -s __tests__/unit/components/ToastNotification.test.js specific` *(fails: missing dependencies)*
