### PR TITLE
Fix axios mock export and improve timer tests

### DIFF
--- a/__mocks__/axios.js
+++ b/__mocks__/axios.js
@@ -66,3 +66,5 @@ axios.get.mockImplementation((url, config) => {
 });
 
 module.exports = axios;
+module.exports.default = axios;
+module.exports.__esModule = true;

--- a/__tests__/unit/components/ToastNotification.test.js
+++ b/__tests__/unit/components/ToastNotification.test.js
@@ -31,12 +31,15 @@ describe('ToastNotificationコンポーネント', () => {
 
     act(() => {
       jest.advanceTimersByTime(1000);
-      jest.runOnlyPendingTimers();
+      jest.runAllTimers();
     });
 
-    await waitFor(() => {
-      expect(screen.queryByText('Hello')).not.toBeInTheDocument();
-    });
+    await waitFor(
+      () => {
+        expect(screen.queryByText('Hello')).not.toBeInTheDocument();
+      },
+      { timeout: 1500 }
+    );
   });
 
   it('閉じるボタンで手動で閉じることができる', async () => {
@@ -45,16 +48,19 @@ describe('ToastNotificationコンポーネント', () => {
 
     expect(screen.getByText('Bye')).toBeInTheDocument();
 
-    const user = userEvent.setup();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     await user.click(screen.getByRole('button'));
 
     act(() => {
-      jest.runOnlyPendingTimers();
+      jest.runAllTimers();
     });
 
-    await waitFor(() => {
-      expect(screen.queryByText('Bye')).not.toBeInTheDocument();
-    });
+    await waitFor(
+      () => {
+        expect(screen.queryByText('Bye')).not.toBeInTheDocument();
+      },
+      { timeout: 1500 }
+    );
     expect(handleClose).toHaveBeenCalled();
   });
 });

--- a/__tests__/unit/services/adminService.test.js
+++ b/__tests__/unit/services/adminService.test.js
@@ -30,7 +30,7 @@ describe('adminService', () => {
 
   it('getStatus が正常にデータを返す', async () => {
     const mockClient = { get: jest.fn().mockResolvedValue({ data: { status: 'ok' } }), post: jest.fn(), defaults: { headers: {} } };
-    axios.create.mockReturnValue(mockClient);
+    axios.create.mockReturnValueOnce(mockClient);
     const { getStatus } = loadModule();
 
     const result = await getStatus();
@@ -42,7 +42,7 @@ describe('adminService', () => {
   it('getStatus がエラー時にエラーレスポンスを返す', async () => {
     const error = { message: 'fail', response: { status: 500 } };
     const mockClient = { get: jest.fn().mockRejectedValue(error), post: jest.fn(), defaults: { headers: {} } };
-    axios.create.mockReturnValue(mockClient);
+    axios.create.mockReturnValueOnce(mockClient);
     const { getStatus } = loadModule();
 
     const result = await getStatus();
@@ -52,7 +52,7 @@ describe('adminService', () => {
 
   it('resetUsage が正常にデータを返す', async () => {
     const mockClient = { get: jest.fn(), post: jest.fn().mockResolvedValue({ data: { reset: true } }), defaults: { headers: {} } };
-    axios.create.mockReturnValue(mockClient);
+    axios.create.mockReturnValueOnce(mockClient);
     const { resetUsage } = loadModule();
 
     const result = await resetUsage();
@@ -64,7 +64,7 @@ describe('adminService', () => {
   it('resetUsage がエラー時にエラーレスポンスを返す', async () => {
     const error = { message: 'oops', response: { status: 403 } };
     const mockClient = { get: jest.fn(), post: jest.fn().mockRejectedValue(error), defaults: { headers: {} } };
-    axios.create.mockReturnValue(mockClient);
+    axios.create.mockReturnValueOnce(mockClient);
     const { resetUsage } = loadModule();
 
     const result = await resetUsage();
@@ -74,7 +74,7 @@ describe('adminService', () => {
 
   it('setAdminApiKey はヘッダーを設定して true を返す', () => {
     const mockClient = { get: jest.fn(), post: jest.fn(), defaults: { headers: {} } };
-    axios.create.mockReturnValue(mockClient);
+    axios.create.mockReturnValueOnce(mockClient);
     const { setAdminApiKey } = loadModule();
 
     const result = setAdminApiKey('new-key');
@@ -85,7 +85,7 @@ describe('adminService', () => {
 
   it('setAdminApiKey は falsy 値では何もしない', () => {
     const mockClient = { get: jest.fn(), post: jest.fn(), defaults: { headers: {} } };
-    axios.create.mockReturnValue(mockClient);
+    axios.create.mockReturnValueOnce(mockClient);
     const { setAdminApiKey } = loadModule();
 
     const result = setAdminApiKey('');

--- a/__tests__/unit/utils/apiUtils.token.test.js
+++ b/__tests__/unit/utils/apiUtils.token.test.js
@@ -32,8 +32,8 @@ describe('auth token utils', () => {
 
   it('request interceptor attaches Authorization header', () => {
     const requestUse = jest.fn();
-    axios.create.mockReturnValue({ interceptors: { request: { use: requestUse }, response: { use: jest.fn() } } });
     const { createApiClient, setAuthToken } = loadModule();
+    axios.create.mockReturnValueOnce({ interceptors: { request: { use: requestUse }, response: { use: jest.fn() } } });
     setAuthToken('abcd');
     createApiClient(true);
     expect(requestUse).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- expose default export on axios mock
- stabilize ToastNotification timer-based tests
- ensure per-test axios mock instances in adminService and token util tests
- adjust token interceptor test after module load
- use userEvent timers for ToastNotification

## Testing
- `npm run test:all` *(fails: connect EHOSTUNREACH)*