### PR TITLE
Fix unit tests for token and toast component

### DIFF
--- a/__tests__/unit/components/ToastNotification.test.js
+++ b/__tests__/unit/components/ToastNotification.test.js
@@ -29,9 +29,8 @@ describe('ToastNotificationコンポーネント', () => {
 
     expect(screen.getByText('Hello')).toBeInTheDocument();
 
-    act(() => {
+    await act(async () => {
       jest.advanceTimersByTime(1000);
-      jest.runAllTimers();
     });
 
     await waitFor(
@@ -51,7 +50,7 @@ describe('ToastNotificationコンポーネント', () => {
     const user = userEvent.setup();
     await user.click(screen.getByRole('button'));
 
-    act(() => {
+    await act(async () => {
       jest.runAllTimers();
     });
 


### PR DESCRIPTION
## Summary
- stabilize axios mock setup for token tests
- ensure async timers flush correctly in ToastNotification tests

## Testing
- `npm run test:all` *(fails: EHOSTUNREACH)*