### PR TITLE
Fix token and toast tests

### DIFF
--- a/__tests__/unit/components/ToastNotification.test.js
+++ b/__tests__/unit/components/ToastNotification.test.js
@@ -24,21 +24,16 @@ describe('ToastNotificationコンポーネント', () => {
     jest.useRealTimers();
   });
 
-  it('指定されたメッセージを表示し、時間経過後に自動で閉じる', async () => {
+  it('指定されたメッセージを表示し、時間経過後に自動で閉じる', () => {
     render(<ToastNotification message="Hello" duration={1000} />);
 
     expect(screen.getByText('Hello')).toBeInTheDocument();
 
-    await act(async () => {
+    act(() => {
       jest.advanceTimersByTime(1000);
     });
 
-    await waitFor(
-      () => {
-        expect(screen.queryByText('Hello')).not.toBeInTheDocument();
-      },
-      { timeout: 1500 }
-    );
+    expect(screen.queryByText('Hello')).not.toBeInTheDocument();
   });
 
   it('閉じるボタンで手動で閉じることができる', async () => {
@@ -47,19 +42,14 @@ describe('ToastNotificationコンポーネント', () => {
 
     expect(screen.getByText('Bye')).toBeInTheDocument();
 
-    const user = userEvent.setup();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     await user.click(screen.getByRole('button'));
 
-    await act(async () => {
+    act(() => {
       jest.runAllTimers();
     });
 
-    await waitFor(
-      () => {
-        expect(screen.queryByText('Bye')).not.toBeInTheDocument();
-      },
-      { timeout: 1500 }
-    );
+    expect(screen.queryByText('Bye')).not.toBeInTheDocument();
     expect(handleClose).toHaveBeenCalled();
   });
 });

--- a/__tests__/unit/utils/apiUtils.token.test.js
+++ b/__tests__/unit/utils/apiUtils.token.test.js
@@ -37,6 +37,8 @@ describe('auth token utils', () => {
   });
 
   it('request interceptor attaches Authorization header', () => {
+    const { createApiClient, setAuthToken } = loadModule();
+
     const requestUse = jest.fn();
     axios.create.mockReturnValueOnce({
       interceptors: {
@@ -45,7 +47,6 @@ describe('auth token utils', () => {
       }
     });
 
-    const { createApiClient, setAuthToken } = loadModule();
     setAuthToken('abcd');
 
     // create client which registers interceptor


### PR DESCRIPTION
## Summary
- fix API token interceptor test so axios mock is applied correctly
- update ToastNotification test to work with fake timers

## Testing
- `npm run test:all` *(fails: connect EHOSTUNREACH)*