### PR TITLE
Fix toast notification tests

### DIFF
--- a/__tests__/unit/components/ToastNotification.test.js
+++ b/__tests__/unit/components/ToastNotification.test.js
@@ -9,14 +9,14 @@
  */
 
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
 import ToastNotification from '@/components/common/ToastNotification';
 
 describe('ToastNotificationコンポーネント', () => {
   beforeEach(() => {
-    jest.useFakeTimers({ legacyFakeTimers: true });
+    jest.useFakeTimers();
   });
 
   afterEach(() => {
@@ -31,7 +31,6 @@ describe('ToastNotificationコンポーネント', () => {
 
     act(() => {
       jest.advanceTimersByTime(1000);
-      jest.runOnlyPendingTimers();
     });
 
     expect(screen.queryByText('Hello')).not.toBeInTheDocument();
@@ -43,15 +42,33 @@ describe('ToastNotificationコンポーネント', () => {
 
     expect(screen.getByText('Bye')).toBeInTheDocument();
 
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const user = userEvent.setup();
     await user.click(screen.getByRole('button'));
 
     act(() => {
       jest.runAllTimers();
-      jest.runOnlyPendingTimers();
     });
 
     expect(screen.queryByText('Bye')).not.toBeInTheDocument();
     expect(handleClose).toHaveBeenCalled();
+  });
+
+  it('type と position に応じたクラスを適用する', () => {
+    const { container } = render(
+      <ToastNotification message="Info" type="success" position="top" />
+    );
+
+    const wrapper = container.firstChild.firstChild;
+    expect(wrapper.className).toContain('border-green-500');
+  });
+
+  it('duration=0 の場合は自動で閉じない', () => {
+    render(<ToastNotification message="Persist" duration={0} />);
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(screen.getByText('Persist')).toBeInTheDocument();
   });
 });

--- a/document/test-files.md
+++ b/document/test-files.md
@@ -31,3 +31,16 @@ npm run test:all
 ```
 
 テスト結果は `test-results/`、カバレッジレポートは `coverage/` に出力されます。
+
+## 追加テスト
+
+カバレッジ向上のため、`ToastNotification` コンポーネントに
+以下のユースケースを網羅したテストを追加しました。
+
+- 自動消去の動作確認
+- 手動閉じる操作の確認
+- 通知タイプと表示位置によるスタイルの適用確認
+- `duration=0` 指定時は自動で閉じないことの確認
+
+これらのテストは `__tests__/unit/components/ToastNotification.test.js`
+に実装されており、`script/run-tests.sh all` で他のテストと共に実行されます。


### PR DESCRIPTION
## Summary
- update ToastNotification tests to avoid timer timeouts
- add more cases for styling and persistent messages
- document the new ToastNotification test scenarios

## Testing
- `npm run test:all` *(fails: request to https://registry.npmjs.org/cross-env failed)*