### PR TITLE
Add tests for API helpers and web vitals

### DIFF
--- a/__tests__/unit/services/api.test.js
+++ b/__tests__/unit/services/api.test.js
@@ -1,0 +1,52 @@
+import { getApiEndpoint, fetchFundInfo, fetchDividendData, checkDataFreshness, initGoogleDriveAPI, setGoogleAccessToken, getGoogleAccessToken, saveToGoogleDrive, loadFromGoogleDrive } from '@/services/api';
+import * as marketDataService from '@/services/marketDataService';
+
+describe('api service helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.REACT_APP_MARKET_DATA_API_URL = 'https://api.example.com';
+    process.env.REACT_APP_API_STAGE = 'v1';
+  });
+
+  it('getApiEndpoint returns proper urls', () => {
+    expect(getApiEndpoint('market-data')).toBe('https://api.example.com/v1/api/market-data');
+    expect(getApiEndpoint('auth')).toBe('https://api.example.com/v1/auth');
+    expect(getApiEndpoint('drive')).toBe('https://api.example.com/v1/drive');
+    expect(getApiEndpoint('other')).toBe('https://api.example.com/v1');
+  });
+
+  it('fetchFundInfo delegates to fetchTickerData', async () => {
+    jest.spyOn(marketDataService, 'fetchStockData').mockResolvedValue('data');
+    const result = await fetchFundInfo('1234');
+    expect(marketDataService.fetchStockData).toHaveBeenCalledWith('1234');
+    expect(result).toBe('data');
+  });
+
+  it('fetchDividendData delegates to fetchTickerData', async () => {
+    jest.spyOn(marketDataService, 'fetchStockData').mockResolvedValue('data');
+    const result = await fetchDividendData('ABC');
+    expect(marketDataService.fetchStockData).toHaveBeenCalledWith('ABC');
+    expect(result).toBe('data');
+  });
+
+  it('checkDataFreshness returns default response', async () => {
+    await expect(checkDataFreshness()).resolves.toEqual({ success: true, fresh: true });
+  });
+
+  it('initGoogleDriveAPI returns deprecated stub functions', async () => {
+    const drive = initGoogleDriveAPI();
+    const save = await drive.saveFile({});
+    const load = await drive.loadFile('id');
+    const list = await drive.listFiles();
+    expect(save).toEqual({ success: false, message: expect.any(String) });
+    expect(load).toEqual({ success: false, message: expect.any(String) });
+    expect(list).toEqual({ success: false, message: expect.any(String) });
+  });
+
+  it('deprecated Google Drive helpers return fallback values', async () => {
+    expect(setGoogleAccessToken('token')).toBeUndefined();
+    await expect(getGoogleAccessToken()).resolves.toBeNull();
+    await expect(saveToGoogleDrive({}, {})).resolves.toEqual({ success: false, message: expect.any(String) });
+    await expect(loadFromGoogleDrive({}, 'file')).resolves.toEqual({ success: false, message: expect.any(String) });
+  });
+});

--- a/__tests__/unit/utils/reportWebVitals.test.js
+++ b/__tests__/unit/utils/reportWebVitals.test.js
@@ -1,0 +1,32 @@
+import reportWebVitals from '@/reportWebVitals';
+
+jest.mock('web-vitals', () => ({
+  getCLS: jest.fn(),
+  getFID: jest.fn(),
+  getFCP: jest.fn(),
+  getLCP: jest.fn(),
+  getTTFB: jest.fn(),
+}));
+
+const webVitals = require('web-vitals');
+
+describe('reportWebVitals utility', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls web-vitals functions when callback provided', async () => {
+    const cb = jest.fn();
+    await reportWebVitals(cb);
+    expect(webVitals.getCLS).toHaveBeenCalledWith(cb);
+    expect(webVitals.getFID).toHaveBeenCalledWith(cb);
+    expect(webVitals.getFCP).toHaveBeenCalledWith(cb);
+    expect(webVitals.getLCP).toHaveBeenCalledWith(cb);
+    expect(webVitals.getTTFB).toHaveBeenCalledWith(cb);
+  });
+
+  it('does nothing when callback is missing', () => {
+    reportWebVitals();
+    expect(webVitals.getCLS).not.toHaveBeenCalled();
+  });
+});

--- a/document/test-files.md
+++ b/document/test-files.md
@@ -55,3 +55,10 @@ npm run test:all
 
 これらのテストは `__tests__/unit/components` 配下にあり、
 各コンポーネントの表示内容とハンドラ呼び出しを検証します。
+
+APIユーティリティ層の網羅率向上のため、`src/services/api.js` の
+補助関数群にもテストを追加しました。動作確認は
+`__tests__/unit/services/api.test.js` に実装しています。
+また、Web Vitals 計測ユーティリティ `src/reportWebVitals.js` 用の
+テスト `__tests__/unit/utils/reportWebVitals.test.js` も追加し、
+コールバックが正しく各計測関数へ渡されるかを検証しています。


### PR DESCRIPTION
## Summary
- add unit tests for deprecated API helpers in `src/services/api.js`
- add unit tests for `reportWebVitals`
- document new test files in `document/test-files.md`

## Testing
- `npm run test:all` *(fails: EHOSTUNREACH)*