### PR TITLE
Add integration and E2E test stubs

### DIFF
--- a/__tests__/e2e/DataOperations_test.js
+++ b/__tests__/e2e/DataOperations_test.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { setupServer } from 'msw/node';
+import { handlers } from '../mocks/handlers';
+import App from '@/App';
+import * as api from '@/services/api';
+
+jest.mock('@react-oauth/google', () => ({
+  GoogleOAuthProvider: ({ children }) => <div>{children}</div>,
+  GoogleLogin: ({ onSuccess }) => (
+    <button onClick={() => onSuccess({ code: 'abc' })}>GoogleLogin</button>
+  )
+}));
+
+jest.mock('@/services/api');
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  api.fetchTickerData.mockResolvedValue({
+    success: true,
+    data: {
+      id: '1',
+      ticker: 'AAPL',
+      name: 'Apple Inc.',
+      price: 100,
+      currency: 'USD',
+      fundType: 'STOCK',
+      hasDividend: true,
+      dividendYield: 0.5,
+      dividendFrequency: 'quarterly',
+      dividendIsEstimated: false,
+      source: 'Market Data API'
+    }
+  });
+  api.fetchFundInfo.mockResolvedValue({ success: true, annualFee: 0 });
+  api.fetchDividendData.mockResolvedValue({
+    success: true,
+    data: {
+      hasDividend: true,
+      dividendYield: 0.5,
+      dividendFrequency: 'quarterly',
+      dividendIsEstimated: false
+    }
+  });
+});
+
+const server = setupServer(...handlers);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+test('user can add ticker after login', async () => {
+  render(<App />);
+
+  await userEvent.click(screen.getByText('GoogleLogin'));
+  expect(await screen.findByText('テストユーザー')).toBeInTheDocument();
+
+  await userEvent.click(screen.getByText('設定'));
+  const input = await screen.findByPlaceholderText(/例: AAPL/i);
+  await userEvent.type(input, 'AAPL');
+  await userEvent.click(screen.getByRole('button', { name: '追加' }));
+
+  expect(await screen.findByText('銘柄を追加しました')).toBeInTheDocument();
+});

--- a/__tests__/e2e/UserManagement_test.js
+++ b/__tests__/e2e/UserManagement_test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { setupServer } from 'msw/node';
+import { handlers } from '../mocks/handlers';
+import App from '@/App';
+
+jest.mock('@react-oauth/google', () => ({
+  GoogleOAuthProvider: ({ children }) => <div>{children}</div>,
+  GoogleLogin: ({ onSuccess }) => (
+    <button onClick={() => onSuccess({ code: 'abc' })}>GoogleLogin</button>
+  )
+}));
+
+const server = setupServer(...handlers);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+test('user can login and logout', async () => {
+  render(<App />);
+
+  await userEvent.click(screen.getByText('GoogleLogin'));
+  expect(await screen.findByText('テストユーザー')).toBeInTheDocument();
+
+  await userEvent.click(screen.getByText('ログアウト'));
+  expect(await screen.findByText('GoogleLogin')).toBeInTheDocument();
+});

--- a/__tests__/integration/api/dataFlow.test.js
+++ b/__tests__/integration/api/dataFlow.test.js
@@ -1,0 +1,16 @@
+import { setupServer } from 'msw/node';
+import { handlers } from '../../mocks/handlers';
+import { fetchMultipleStocks } from '@/services/marketDataService';
+
+const server = setupServer(...handlers);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+test('fetchMultipleStocks retrieves data for multiple tickers', async () => {
+  const result = await fetchMultipleStocks(['AAPL', '7203.T']);
+  expect(result.success).toBe(true);
+  expect(result.data).toHaveProperty('AAPL');
+  expect(result.data).toHaveProperty('7203.T');
+});

--- a/__tests__/integration/auth/googleAuth.test.js
+++ b/__tests__/integration/auth/googleAuth.test.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { setupServer } from 'msw/node';
+import { handlers } from '../../mocks/handlers';
+import { AuthProvider } from '@/context/AuthContext';
+import useAuth from '@/hooks/useAuth';
+
+const server = setupServer(...handlers);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const wrapper = ({ children }) => <AuthProvider>{children}</AuthProvider>;
+
+test('Google login updates authentication state', async () => {
+  const { result } = renderHook(() => useAuth(), { wrapper });
+
+  await act(async () => {
+    const success = await result.current.loginWithGoogle({ code: 'abc' });
+    expect(success).toBe(true);
+  });
+
+  expect(result.current.isAuthenticated).toBe(true);
+  expect(result.current.user).toEqual(expect.objectContaining({ email: expect.any(String) }));
+});

--- a/__tests__/integration/forms/userForm.test.js
+++ b/__tests__/integration/forms/userForm.test.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PortfolioProvider } from '@/context/PortfolioContext';
+import TickerSearch from '@/components/settings/TickerSearch';
+import * as api from '@/services/api';
+
+jest.mock('@/services/api');
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  api.fetchTickerData.mockResolvedValue({
+    success: true,
+    data: {
+      id: '1',
+      ticker: 'AAPL',
+      name: 'Apple Inc.',
+      price: 100,
+      currency: 'USD',
+      fundType: 'STOCK',
+      hasDividend: true,
+      dividendYield: 0.5,
+      dividendFrequency: 'quarterly',
+      dividendIsEstimated: false,
+      source: 'Market Data API'
+    }
+  });
+  api.fetchFundInfo.mockResolvedValue({ success: true, annualFee: 0 });
+  api.fetchDividendData.mockResolvedValue({
+    success: true,
+    data: {
+      hasDividend: true,
+      dividendYield: 0.5,
+      dividendFrequency: 'quarterly',
+      dividendIsEstimated: false
+    }
+  });
+});
+
+const wrapper = ({ children }) => <PortfolioProvider>{children}</PortfolioProvider>;
+
+test('user can add ticker via form', async () => {
+  render(<TickerSearch />, { wrapper });
+  const input = screen.getByPlaceholderText(/例: AAPL/i);
+  await userEvent.type(input, 'AAPL');
+  await userEvent.click(screen.getByRole('button', { name: '追加' }));
+  expect(await screen.findByText('銘柄を追加しました')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- implement integration tests for auth, user form, and data flow
- add E2E tests covering login/logout and ticker operations

## Testing
- `npm run test:all` *(fails: connect EHOSTUNREACH)*