### PR TITLE
Fix MSW path to respect API stage

### DIFF
--- a/__tests__/mocks/handlers.js
+++ b/__tests__/mocks/handlers.js
@@ -14,8 +14,9 @@ import { mockMarketData, mockExchangeRate, mockUserProfile } from './data';
 
 // 基本的なAPIパスの構築
 const getApiPath = (path) => {
-  // テスト環境ではAPI_STAGEはdevを使用
-  return `*/dev/${path}`;
+  // テスト環境のAPIステージを環境変数から取得
+  const stage = process.env.REACT_APP_API_STAGE || 'dev';
+  return `*/${stage}/${path}`;
 };
 
 // MSWハンドラー


### PR DESCRIPTION
## Summary
- adjust MSW API handlers so that the stage is read from `REACT_APP_API_STAGE`

## Testing
- `npm run test:all` *(fails: missing network access to install dependencies)*