### PR TITLE
Add test for run-tests.sh

### DIFF
--- a/__tests__/unit/scripts/runTestsSh.test.js
+++ b/__tests__/unit/scripts/runTestsSh.test.js
@@ -1,5 +1,7 @@
 const { spawnSync } = require('child_process');
 const path = require('path');
+const fs = require('fs');
+const os = require('os');
 
 describe('run-tests.sh helper', () => {
   const script = path.resolve(__dirname, '../../../script/run-tests.sh');
@@ -14,5 +16,29 @@ describe('run-tests.sh helper', () => {
     const result = spawnSync('bash', [script, '--unknown'], { encoding: 'utf8' });
     expect(result.status).not.toBe(0);
     expect(result.stdout).toContain('不明なオプション');
+  });
+
+  test('runs all tests using stubbed npx', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'npx-'));
+    const bin = path.join(tmp, 'bin');
+    fs.mkdirSync(bin);
+    const log = path.join(tmp, 'log');
+    fs.writeFileSync(
+      path.join(bin, 'npx'),
+      `#!/bin/sh\necho "$@" > "${log}"\n`,
+      { mode: 0o755 }
+    );
+
+    const env = { ...process.env, PATH: `${bin}:${process.env.PATH}` };
+    const result = spawnSync('bash', [script, 'all'], { encoding: 'utf8', env });
+
+    const cmd = fs.readFileSync(log, 'utf8');
+
+    // clean up
+    fs.rmSync(tmp, { recursive: true, force: true });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('すべてのテストを実行中');
+    expect(cmd).toContain('jest');
   });
 });

--- a/custom-reporter.js
+++ b/custom-reporter.js
@@ -1473,7 +1473,7 @@ class CustomReporter {
                   <div class="card-title">コードカバレッジ分析</div>
                   <div class="coverage-warning">
                     <p>カバレッジ情報が利用できません。テスト実行時に以下のコマンドを使用してください：</p>
-                    <pre style="margin-top: 10px; background: #000; padding: 10px; border-radius: 3px;">./scripts/run-tests.sh --force-coverage ${process.argv.slice(2).join(' ')}</pre>
+                    <pre style="margin-top: 10px; background: #000; padding: 10px; border-radius: 3px;">./script/run-tests.sh --force-coverage ${process.argv.slice(2).join(' ')}</pre>
                   </div>
                 </div>
                 `}
@@ -1715,7 +1715,7 @@ class CustomReporter {
     } else {
       console.log(`${yellow}⚠ カバレッジデータが結果ファイルに含まれていません。${reset}`);
       console.log(`${blue}次回のテスト実行時には以下のコマンドを使用してください：${reset}`);
-      console.log(`${yellow}./scripts/run-tests.sh --force-coverage ${process.argv.slice(2).join(' ')}${reset}`);
+      console.log(`${yellow}./script/run-tests.sh --force-coverage ${process.argv.slice(2).join(' ')}${reset}`);
     }
     
     console.log('========================================');

--- a/script/fix-node-version.sh
+++ b/script/fix-node-version.sh
@@ -92,5 +92,5 @@ fi
 echo -e "${BLUE}===============================================${NC}"
 echo -e "${GREEN}Node.jsバージョン修正完了${NC}"
 echo -e "テスト実行コマンド例:"
-echo -e "${YELLOW}./scripts/run-tests.sh --no-coverage integration${NC}"
+echo -e "${YELLOW}./script/run-tests.sh --no-coverage integration${NC}"
 


### PR DESCRIPTION
## Summary
- expand tests for `run-tests.sh` to cover `all` option using a stubbed npx command
- fix references to the script path in documentation scripts

## Testing
- `npm run test:all` *(fails: request to https://registry.npmjs.org/cross-env failed)*