### PR TITLE
Add CLI test for coverage chart generator

### DIFF
--- a/__tests__/unit/scripts/generateCoverageChartCli.test.js
+++ b/__tests__/unit/scripts/generateCoverageChartCli.test.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+function withTempDir(fn) {
+  const tmp = fs.mkdtempSync(path.join(require('os').tmpdir(), 'gcc-'));
+  const cwd = process.cwd();
+  process.chdir(tmp);
+  try {
+    return fn(tmp);
+  } finally {
+    process.chdir(cwd);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+describe('generate-coverage-chart CLI', () => {
+  const script = path.resolve(__dirname, '../../../script/generate-coverage-chart.js');
+
+  test('runs main and outputs svg files', () => {
+    withTempDir(() => {
+      const coverage = {
+        total: {
+          statements: { covered: 1, total: 1, pct: 100 },
+          branches: { covered: 1, total: 1, pct: 100 },
+          functions: { covered: 1, total: 1, pct: 100 },
+          lines: { covered: 1, total: 1, pct: 100 }
+        }
+      };
+      fs.mkdirSync('coverage', { recursive: true });
+      fs.writeFileSync('coverage/coverage-summary.json', JSON.stringify(coverage));
+      fs.mkdirSync('test-results', { recursive: true });
+      fs.writeFileSync('test-results/visual-report.html', '<html><body></body></html>');
+
+      const env = { ...process.env, COVERAGE_TARGET: 'initial' };
+      const res = spawnSync('node', [script], { encoding: 'utf8', env });
+      expect(res.status).toBe(0);
+      expect(fs.existsSync('test-results/coverage-bar-chart.svg')).toBe(true);
+      expect(fs.existsSync('test-results/coverage-line-chart.svg')).toBe(true);
+    });
+  });
+});

--- a/document/test-files.md
+++ b/document/test-files.md
@@ -102,3 +102,4 @@ APIユーティリティ層の網羅率向上のため、`src/services/api.js` �
 - `fundUtils.extra.test.js` では `guessFundType`、`estimateAnnualFee`、`estimateDividendYield` の未カバーケースを追加し、REIT や債券、暗号資産、空文字ティッカーなどの判定を検証しています。
 - `customReporter.test.js` ではカスタムJestレポーターのユーティリティ関数をテストし、デモカバレッジ生成やサマリー表示処理を確認しています。
 - `setupProxy.test.js` では Express アプリへのプロキシミドルウェア登録処理をテストし、環境変数の設定と `http-proxy-middleware` の呼び出し内容を検証しています。
+- `generateCoverageChartCli.test.js` では CLIとして `script/generate-coverage-chart.js` を実行し、SVGファイル生成と終了ステータスを検証しています。


### PR DESCRIPTION
## Summary
- add new unit test to invoke `generate-coverage-chart.js` via CLI
- document the new test in test-files.md

## Testing
- `./script/run-tests.sh all` *(fails: request to https://registry.npmjs.org/jest failed)*