### PR TITLE
Add tests for dashboard and simulation components

### DIFF
--- a/__tests__/unit/components/AiAnalysisPrompt.test.js
+++ b/__tests__/unit/components/AiAnalysisPrompt.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AiAnalysisPrompt from '@/components/simulation/AiAnalysisPrompt';
+
+jest.mock('@/hooks/usePortfolioContext', () => ({
+  usePortfolioContext: jest.fn(),
+}));
+
+const { usePortfolioContext } = require('@/hooks/usePortfolioContext');
+
+describe('AiAnalysisPrompt', () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: jest.fn().mockResolvedValue() },
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('copies prompt to clipboard', async () => {
+    usePortfolioContext.mockReturnValue({
+      currentAssets: [],
+      targetPortfolio: [],
+      additionalBudget: { amount: 0, currency: 'USD' },
+      baseCurrency: 'USD',
+      exchangeRate: { rate: 150 },
+      totalAssets: 0,
+    });
+
+    render(<AiAnalysisPrompt />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'プロンプトをコピー' }));
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalled();
+    expect(screen.getByText('コピー完了')).toBeInTheDocument();
+  });
+});

--- a/__tests__/unit/components/DifferenceChart.test.js
+++ b/__tests__/unit/components/DifferenceChart.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import DifferenceChart from '@/components/dashboard/DifferenceChart';
+
+jest.mock('@/hooks/usePortfolioContext', () => ({
+  usePortfolioContext: jest.fn(),
+}));
+
+jest.mock('recharts', () => {
+  const Original = jest.requireActual('recharts');
+  return {
+    ...Original,
+    ResponsiveContainer: ({ children }) => <div data-testid="responsive-container">{children}</div>,
+    BarChart: ({ children }) => <div data-testid="bar-chart">{children}</div>,
+    Bar: () => <div data-testid="bar"></div>,
+    CartesianGrid: () => <div data-testid="grid"></div>,
+    XAxis: () => <div data-testid="x"></div>,
+    YAxis: () => <div data-testid="y"></div>,
+    Tooltip: () => <div data-testid="tooltip"></div>,
+  };
+});
+
+const { usePortfolioContext } = require('@/hooks/usePortfolioContext');
+
+describe('DifferenceChart', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders placeholder when no data', () => {
+    usePortfolioContext.mockReturnValue({
+      currentAssets: [],
+      targetPortfolio: [],
+      baseCurrency: 'USD',
+      totalAssets: 0,
+      exchangeRate: { rate: 150 },
+    });
+
+    render(<DifferenceChart />);
+
+    expect(screen.getByText('表示するデータがありません。目標配分を設定してください。')).toBeInTheDocument();
+  });
+
+  it('renders chart when data exists', () => {
+    usePortfolioContext.mockReturnValue({
+      currentAssets: [
+        { id: 1, ticker: 'AAPL', name: 'Apple', price: 100, holdings: 5, currency: 'USD' },
+      ],
+      targetPortfolio: [
+        { id: 1, ticker: 'AAPL', name: 'Apple', targetPercentage: 60 },
+      ],
+      baseCurrency: 'USD',
+      totalAssets: 500,
+      exchangeRate: { rate: 150 },
+    });
+
+    render(<DifferenceChart />);
+
+    expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+  });
+});

--- a/__tests__/unit/components/ImportOptions.test.js
+++ b/__tests__/unit/components/ImportOptions.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ImportOptions from '@/components/data/ImportOptions';
+
+jest.mock('papaparse', () => ({
+  parse: jest.fn(() => ({ data: [] })),
+}));
+
+jest.mock('@/hooks/usePortfolioContext', () => ({
+  usePortfolioContext: jest.fn(),
+}));
+
+const { usePortfolioContext } = require('@/hooks/usePortfolioContext');
+const Papa = require('papaparse');
+
+describe('ImportOptions', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('imports data from text input', async () => {
+    const importPortfolioData = jest.fn();
+    usePortfolioContext.mockReturnValue({ importPortfolioData });
+
+    render(<ImportOptions />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('radio', { name: 'テキスト入力' }));
+    const textarea = screen.getByLabelText('データを貼り付け');
+    await user.type(textarea, '{"currentAssets":[],"targetPortfolio":[]}');
+    await user.click(screen.getByRole('button', { name: 'インポート' }));
+
+    expect(importPortfolioData).toHaveBeenCalled();
+    expect(Papa.parse).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/components/PortfolioCharts.test.js
+++ b/__tests__/unit/components/PortfolioCharts.test.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import PortfolioCharts from '@/components/dashboard/PortfolioCharts';
+
+jest.mock('@/hooks/usePortfolioContext', () => ({
+  usePortfolioContext: jest.fn(),
+}));
+
+// Mock recharts similar to Chart tests
+jest.mock('recharts', () => {
+  const Original = jest.requireActual('recharts');
+  return {
+    ...Original,
+    ResponsiveContainer: ({ children }) => <div data-testid="responsive-container">{children}</div>,
+    PieChart: ({ children }) => <div data-testid="pie-chart">{children}</div>,
+    Pie: ({ children }) => <div data-testid="pie">{children}</div>,
+    Cell: ({ fill }) => <div data-testid="cell" style={{ backgroundColor: fill }}></div>,
+    Tooltip: () => <div data-testid="tooltip"></div>,
+    Legend: () => <div data-testid="legend"></div>,
+  };
+});
+
+const { usePortfolioContext } = require('@/hooks/usePortfolioContext');
+
+describe('PortfolioCharts', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders two pie charts', () => {
+    usePortfolioContext.mockReturnValue({
+      currentAssets: [
+        { ticker: 'AAPL', name: 'Apple', price: 100, holdings: 5, currency: 'USD' },
+      ],
+      targetPortfolio: [
+        { ticker: 'AAPL', name: 'Apple', targetPercentage: 50 },
+      ],
+      baseCurrency: 'USD',
+      totalAssets: 500,
+      exchangeRate: { rate: 150 },
+    });
+
+    render(<PortfolioCharts />);
+
+    expect(screen.getAllByTestId('pie-chart')).toHaveLength(2);
+    expect(screen.getByText('理想配分')).toBeInTheDocument();
+    expect(screen.getByText('現在配分')).toBeInTheDocument();
+  });
+});

--- a/__tests__/unit/components/PortfolioSummary.test.js
+++ b/__tests__/unit/components/PortfolioSummary.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import PortfolioSummary from '@/components/dashboard/PortfolioSummary';
+
+jest.mock('@/hooks/usePortfolioContext', () => ({
+  usePortfolioContext: jest.fn(),
+}));
+
+const { usePortfolioContext } = require('@/hooks/usePortfolioContext');
+
+describe('PortfolioSummary', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders summary information', () => {
+    usePortfolioContext.mockReturnValue({
+      baseCurrency: 'USD',
+      totalAssets: 1000,
+      annualFees: 10,
+      annualDividends: 20,
+      currentAssets: [
+        { id: 1, ticker: 'AAPL', name: 'Apple', price: 100, holdings: 5, annualFee: 0.5, dividendYield: 1, hasDividend: true, fundType: 'STOCK', currency: 'USD' },
+      ],
+      targetPortfolio: [
+        { id: 1, ticker: 'AAPL', name: 'Apple', targetPercentage: 50 },
+      ],
+    });
+
+    render(<PortfolioSummary />);
+
+    expect(screen.getByText('ポートフォリオサマリー')).toBeInTheDocument();
+    expect(screen.getByText('総資産')).toBeInTheDocument();
+    expect(screen.getByText('設定銘柄数')).toBeInTheDocument();
+  });
+});

--- a/__tests__/unit/components/SimulationResult.test.js
+++ b/__tests__/unit/components/SimulationResult.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SimulationResult from '@/components/simulation/SimulationResult';
+
+jest.mock('@/hooks/usePortfolioContext', () => ({
+  usePortfolioContext: jest.fn(),
+}));
+
+const { usePortfolioContext } = require('@/hooks/usePortfolioContext');
+
+describe('SimulationResult', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders message when no results', () => {
+    usePortfolioContext.mockReturnValue({
+      baseCurrency: 'USD',
+      exchangeRate: { rate: 150 },
+      calculateSimulation: () => [],
+      executePurchase: jest.fn(),
+    });
+
+    render(<SimulationResult />);
+
+    expect(screen.getByText('シミュレーション結果がありません')).toBeInTheDocument();
+  });
+
+  it('renders table when results exist', () => {
+    usePortfolioContext.mockReturnValue({
+      baseCurrency: 'USD',
+      exchangeRate: { rate: 150 },
+      calculateSimulation: () => [
+        {
+          id: '1',
+          ticker: 'AAPL',
+          name: 'Apple',
+          price: 100,
+          currency: 'USD',
+          currentValue: 100,
+          currentAllocation: 50,
+          targetAllocation: 60,
+          diff: 10,
+          purchaseShares: 1,
+          purchaseAmount: 100,
+        },
+      ],
+      executePurchase: jest.fn(),
+    });
+
+    render(<SimulationResult />);
+
+    expect(screen.getByText('AAPL')).toBeInTheDocument();
+  });
+});

--- a/document/test-files.md
+++ b/document/test-files.md
@@ -93,6 +93,12 @@ APIユーティリティ層の網羅率向上のため、`src/services/api.js` �
 - `GoogleDriveIntegration` コンポーネント
 - `BudgetInput` コンポーネント
 - `ExportOptions` コンポーネント
+- `PortfolioSummary` コンポーネント
+- `PortfolioCharts` コンポーネント
+- `ImportOptions` コンポーネント
+- `SimulationResult` コンポーネント
+- `AiAnalysisPrompt` コンポーネント
+- `DifferenceChart` コンポーネント
 
 いずれも `__tests__/unit/components` 配下にあり、
 データが存在しない場合の表示やユーザー操作による状態遷移を検証します。


### PR DESCRIPTION
## Summary
- increase coverage for dashboard and simulation components
- document new test files

## Testing
- `npm run test:all` *(fails: EHOSTUNREACH)*