### PR TITLE
Add extra coverage tests

### DIFF
--- a/__tests__/unit/scripts/generateCoverageChartExtras.test.js
+++ b/__tests__/unit/scripts/generateCoverageChartExtras.test.js
@@ -1,0 +1,63 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const {
+  debugLog,
+  loadCoverageData,
+  embedChartsInReport,
+} = require('../../../script/generate-coverage-chart');
+
+function withTempDir(fn) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gcc-extra-'));
+  const cwd = process.cwd();
+  process.chdir(tmp);
+  try {
+    return fn(tmp);
+  } finally {
+    process.chdir(cwd);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+describe('generate-coverage-chart extras', () => {
+  afterEach(() => {
+    delete process.env.DEBUG;
+    jest.restoreAllMocks();
+  });
+
+  test('debugLog outputs when DEBUG is true', () => {
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    process.env.DEBUG = 'true';
+    debugLog('msg', { a: 1 });
+    expect(spy).toHaveBeenCalledWith('[DEBUG] msg');
+    expect(spy).toHaveBeenCalledWith(JSON.stringify({ a: 1 }, null, 2));
+  });
+
+  test('loadCoverageData returns null when no files', () => {
+    withTempDir(() => {
+      expect(loadCoverageData()).toBeNull();
+    });
+  });
+
+  test('embedChartsInReport warns when report missing', () => {
+    withTempDir(() => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      embedChartsInReport('<svg></svg>', '<svg></svg>');
+      expect(warn).toHaveBeenCalled();
+    });
+  });
+
+  test('embedChartsInReport warns on malformed html', () => {
+    withTempDir(() => {
+      const report = path.resolve('./test-results/visual-report.html');
+      fs.mkdirSync(path.dirname(report), { recursive: true });
+      fs.writeFileSync(report, '<html>bad');
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      embedChartsInReport('<svg></svg>', '<svg></svg>');
+      expect(warn).toHaveBeenCalled();
+      const html = fs.readFileSync(report, 'utf8');
+      expect(html).toBe('<html>bad');
+    });
+  });
+});

--- a/document/test-files.md
+++ b/document/test-files.md
@@ -114,3 +114,6 @@ APIユーティリティ層の網羅率向上のため、`src/services/api.js` �
 - `runTestsShEdgeCases.test.js` では `--config` オプションによる設定ファイル指定と、`jest` と `npx` が共に存在しない環境でのエラー終了を確認しています。
 - `setupTestEnvExtras.test.js` では 無効な `COVERAGE_TARGET` が `initial` に補正されることと、`script/setup-test-env.js` を CLI として実行した際に必要なディレクトリが生成されるかを確認しています。
 - `runTestsShQuick.test.js` では `quick` テスト種別を実行し、`cross-env` が無い環境で `jest` コマンドも見つからない場合に `npx jest` へフォールバックして実行されることと、`USE_API_MOCKS=true` が環境変数として渡されるかを検証しています。
+
+- `generateCoverageChartExtras.test.js` では `generate-coverage-chart.js` のデバッグ出力やカバレッジファイルが存在しない場合の挙動、\
+  HTMLレポートが欠落している場合の警告表示を検証しています。


### PR DESCRIPTION
## Summary
- add more tests for `generate-coverage-chart.js`
- document the new tests in `test-files.md`

## Testing
- `npm run test:all` *(fails: cross-env not found)*