### PR TITLE
Add test for jest fallback when cross-env missing

### DIFF
--- a/__tests__/unit/scripts/runTestsShNative.test.js
+++ b/__tests__/unit/scripts/runTestsShNative.test.js
@@ -1,0 +1,50 @@
+const { spawnSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+function withTempSetup(fn) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rtnative-'));
+  fs.mkdirSync(path.join(tmp, 'script'));
+  const files = ['run-tests.sh', 'setup-test-env.js'];
+  files.forEach(f => {
+    const src = path.resolve(__dirname, '../../../script', f);
+    const dest = path.join(tmp, 'script', f);
+    fs.copyFileSync(src, dest);
+    if (f.endsWith('.sh')) fs.chmodSync(dest, 0o755);
+  });
+  fs.writeFileSync(path.join(tmp, 'package.json'), '{}');
+  fs.copyFileSync(path.resolve(__dirname, '../../../custom-reporter.js'), path.join(tmp, 'custom-reporter.js'));
+  try {
+    return fn(tmp);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+describe('run-tests.sh with local jest', () => {
+  const script = path.resolve(__dirname, '../../../script/run-tests.sh');
+
+  test('uses local jest when cross-env is missing', () => {
+    withTempSetup(tmp => {
+      const bin = path.join(tmp, 'bin');
+      fs.mkdirSync(bin);
+      const argsLog = path.join(tmp, 'args.log');
+      const envLog = path.join(tmp, 'env.log');
+      fs.writeFileSync(
+        path.join(bin, 'jest'),
+        `#!/bin/sh\necho \"$@\" > \"${argsLog}\"\nprintenv > \"${envLog}\"\n`,
+        { mode: 0o755 }
+      );
+
+      const env = { ...process.env, PATH: `${bin}:${process.env.PATH}` };
+      const res = spawnSync('bash', [path.join(tmp, 'script/run-tests.sh'), 'all'], { cwd: tmp, env, encoding: 'utf8' });
+      const args = fs.readFileSync(argsLog, 'utf8');
+      const envOut = fs.readFileSync(envLog, 'utf8');
+      expect(res.status).toBe(0);
+      expect(res.stdout).toContain('cross-envが見つからないため');
+      expect(args.trim().startsWith('jest')).toBe(true);
+      expect(envOut).toContain('JEST_COVERAGE=true');
+    });
+  });
+});

--- a/document/test-files.md
+++ b/document/test-files.md
@@ -114,6 +114,7 @@ APIユーティリティ層の網羅率向上のため、`src/services/api.js` �
 - `runTestsShEdgeCases.test.js` では `--config` オプションによる設定ファイル指定と、`jest` と `npx` が共に存在しない環境でのエラー終了を確認しています。
 - `setupTestEnvExtras.test.js` では 無効な `COVERAGE_TARGET` が `initial` に補正されることと、`script/setup-test-env.js` を CLI として実行した際に必要なディレクトリが生成されるかを確認しています。
 - `runTestsShQuick.test.js` では `quick` テスト種別を実行し、`cross-env` が無い環境で `jest` コマンドも見つからない場合に `npx jest` へフォールバックして実行されることと、`USE_API_MOCKS=true` が環境変数として渡されるかを検証しています。
+- `runTestsShNative.test.js` では `cross-env` が無いものの `jest` コマンドが存在する環境で、ローカルの `jest` が直接実行され、環境変数が正しく渡されるかを確認しています。
 
 - `generateCoverageChartExtras.test.js` では `generate-coverage-chart.js` のデバッグ出力やカバレッジファイルが存在しない場合の挙動、\
   HTMLレポートが欠落している場合の警告表示を検証しています。


### PR DESCRIPTION
## Summary
- add `runTestsShNative.test.js` to cover scenario where cross-env is absent but `jest` is available
- document new test case in **test-files.md**

## Testing
- `./script/run-tests.sh all` *(fails: npm could not reach registry)*