### PR TITLE
Add wrapper for test script and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,18 @@ DEFAULT_EXCHANGE_RATE=150.0
 4. ブランチにプッシュ (`git push origin feature/amazing-feature`)
 5. プルリクエストを作成
 
+## テストの実行方法
+
+プロジェクトのテストは次のコマンドで実行できます。カバレッジレポートも生成されます。
+
+```bash
+npm run test:all
+# または
+./script/run-tests.sh all
+# 互換ラッパー: ./scripts/run-tests.sh all でも実行可能
+```
+
+
 ## 免責事項
 
 本アプリケーションの利用に関しては、以下の点にご留意ください：

--- a/document/test-files.md
+++ b/document/test-files.md
@@ -1,6 +1,6 @@
 # テストファイル構成
 
-このドキュメントでは、本プロジェクトにおけるテストコードの配置場所と役割を簡潔にまとめます。`npm run test:all` または `script/run-tests.sh all` で全てのテストが実行されます。
+このドキュメントでは、本プロジェクトにおけるテストコードの配置場所と役割を簡潔にまとめます。`npm run test:all` または `script/run-tests.sh all` または `scripts/run-tests.sh all` で全てのテストが実行されます。
 
 ## ディレクトリ構成
 
@@ -28,6 +28,7 @@ __tests__/
 npm run test:all
 # または
 ./script/run-tests.sh all
+./scripts/run-tests.sh all
 ```
 
 テスト結果は `test-results/`、カバレッジレポートは `coverage/` に出力されます。

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Wrapper to maintain backwards compatibility with scripts/run-tests.sh
+DIR="$(dirname "$0")"
+# Execute the real script one directory up
+"$DIR/../script/run-tests.sh" "$@"


### PR DESCRIPTION
## Summary
- add `scripts/run-tests.sh` wrapper for compatibility
- document how to run tests in README
- mention wrapper in test-files docs

## Testing
- `./scripts/run-tests.sh all` *(fails: cross-env not found)*