### PR TITLE
Add run-tests failure case tests

### DIFF
--- a/__tests__/unit/scripts/runTestsShCoverageFailures.test.js
+++ b/__tests__/unit/scripts/runTestsShCoverageFailures.test.js
@@ -1,0 +1,65 @@
+const { spawnSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+function withTempSetup(fn) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rtcovfail-'));
+  fs.mkdirSync(path.join(tmp, 'script'));
+  const files = ['run-tests.sh', 'setup-test-env.js'];
+  files.forEach(f => {
+    const src = path.resolve(__dirname, '../../..', 'script', f);
+    const dest = path.join(tmp, 'script', f);
+    fs.copyFileSync(src, dest);
+    if (f.endsWith('.sh')) fs.chmodSync(dest, 0o755);
+  });
+  fs.writeFileSync(path.join(tmp, 'package.json'), '{}');
+  fs.copyFileSync(path.resolve(__dirname, '../../..', 'custom-reporter.js'), path.join(tmp, 'custom-reporter.js'));
+  try {
+    return fn(tmp);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+describe('run-tests.sh coverage failure cases', () => {
+  const script = path.resolve(__dirname, '../../..', 'script/run-tests.sh');
+
+  test('--validate-coverage warns when results are missing', () => {
+    withTempSetup(tmp => {
+      const bin = path.join(tmp, 'bin');
+      fs.mkdirSync(bin);
+      fs.writeFileSync(path.join(bin, 'npx'), '#!/bin/sh\n"$@"\n', { mode: 0o755 });
+      fs.writeFileSync(path.join(bin, 'cross-env'), '#!/bin/sh\nshift\n"$@"\n', { mode: 0o755 });
+      fs.writeFileSync(path.join(bin, 'jest'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+
+      const env = { ...process.env, PATH: `${bin}:${process.env.PATH}` };
+      const res = spawnSync('bash', [script, '--validate-coverage', 'all'], { cwd: tmp, env, encoding: 'utf8' });
+      expect(res.status).toBe(0);
+      expect(res.stdout).toContain('カバレッジファイルが見つかりません');
+    });
+  });
+
+  test('html coverage opens report on macOS', () => {
+    withTempSetup(tmp => {
+      const bin = path.join(tmp, 'bin');
+      fs.mkdirSync(bin);
+      const openLog = path.join(tmp, 'open.log');
+      fs.writeFileSync(path.join(bin, 'npx'), '#!/bin/sh\n"$@"\n', { mode: 0o755 });
+      fs.writeFileSync(path.join(bin, 'cross-env'), '#!/bin/sh\nshift\n"$@"\n', { mode: 0o755 });
+      fs.writeFileSync(path.join(bin, 'uname'), '#!/bin/sh\necho Darwin\n', { mode: 0o755 });
+      fs.writeFileSync(path.join(bin, 'open'), `#!/bin/sh\necho \"$@\" > \"${openLog}\"\n`, { mode: 0o755 });
+
+      const html = path.join(tmp, 'coverage/lcov-report/index.html');
+      fs.mkdirSync(path.dirname(html), { recursive: true });
+      fs.writeFileSync(html, '<html></html>');
+
+      const env = { ...process.env, PATH: `${bin}:${process.env.PATH}` };
+      const res = spawnSync('bash', [script, '--html-coverage', 'all'], { cwd: tmp, env, encoding: 'utf8' });
+      const openCmd = fs.readFileSync(openLog, 'utf8').trim();
+      expect(res.status).toBe(0);
+      expect(openCmd).toContain('index.html');
+      expect(res.stdout).toContain('HTMLカバレッジレポートを開いています');
+    });
+  });
+});

--- a/document/test-files.md
+++ b/document/test-files.md
@@ -124,3 +124,4 @@ APIユーティリティ層の網羅率向上のため、`src/services/api.js` �
 
 - `generateCoverageChartExtras.test.js` では `generate-coverage-chart.js` のデバッグ出力やカバレッジファイルが存在しない場合の挙動、\
   HTMLレポートが欠落している場合の警告表示を検証しています。
+- `runTestsShCoverageFailures.test.js` では カバレッジ結果が無い場合の警告メッセージと、macOSでHTMLレポートを自動表示する処理を検証しています。


### PR DESCRIPTION
## Summary
- test warning when coverage results are missing
- test macOS HTML coverage open logic
- document new test file

## Testing
- `./script/run-tests.sh all` *(fails: npm could not reach registry)*