### PR TITLE
Improve PortfolioContext test coverage

### DIFF
--- a/__tests__/unit/context/PortfolioContextExtras.test.js
+++ b/__tests__/unit/context/PortfolioContextExtras.test.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { PortfolioProvider, encryptData, decryptData } from '@/context/PortfolioContext';
+import usePortfolioContext from '@/hooks/usePortfolioContext';
+
+const wrapper = ({ children }) => <PortfolioProvider>{children}</PortfolioProvider>;
+
+describe('PortfolioContext additional utilities', () => {
+  test('encryptData and decryptData work symmetrically', () => {
+    const data = { foo: 'bar', num: 1 };
+    const encrypted = encryptData(data);
+    expect(typeof encrypted).toBe('string');
+    const decrypted = decryptData(encrypted);
+    expect(decrypted).toEqual(data);
+  });
+
+  test('encryptData handles circular structure', () => {
+    const obj = {};
+    obj.self = obj;
+    expect(encryptData(obj)).toBeNull();
+  });
+
+  test('decryptData returns null when input is invalid', () => {
+    expect(decryptData('not-base64')).toBeNull();
+  });
+
+  test('exportData returns current portfolio state', () => {
+    const { result } = renderHook(() => usePortfolioContext(), { wrapper });
+    const data = result.current.exportData();
+    expect(data.baseCurrency).toBe('JPY');
+    expect(data.currentAssets).toEqual([]);
+    expect(data.targetPortfolio).toEqual([]);
+    expect(data.additionalBudget).toEqual({ amount: 300000, currency: 'JPY' });
+  });
+
+  test('validateAssetTypes fixes incorrect asset info', () => {
+    const { result } = renderHook(() => usePortfolioContext(), { wrapper });
+    const assets = [{
+      ticker: 'AAPL',
+      name: 'Apple',
+      fundType: 'ETF（米国）',
+      isStock: false,
+      annualFee: 0.5,
+      feeSource: 'test',
+      feeIsEstimated: true,
+      dividendYield: 0,
+      hasDividend: false,
+      dividendFrequency: '',
+      dividendIsEstimated: true
+    }];
+
+    const { updatedAssets, changes } = result.current.validateAssetTypes(assets);
+    expect(updatedAssets[0].fundType).toBe('個別株');
+    expect(updatedAssets[0].isStock).toBe(true);
+    expect(changes.fundType).toBe(1);
+  });
+});

--- a/document/test-files.md
+++ b/document/test-files.md
@@ -104,6 +104,7 @@ APIユーティリティ層の網羅率向上のため、`src/services/api.js` �
 - `HoldingsEditor` コンポーネント
 - `PopularTickers` コンポーネント
 - `AuthContext` の基本動作
+- `PortfolioContextExtras.test.js` では 暗号化関数や `validateAssetTypes`、`exportData` の挙動を検証し、コンテキスト内部の補助機能をカバーしています。
 
 いずれも `__tests__/unit/components` 配下にあり、
 データが存在しない場合の表示やユーザー操作による状態遷移を検証します。

--- a/src/context/PortfolioContext.js
+++ b/src/context/PortfolioContext.js
@@ -1568,3 +1568,6 @@ export const PortfolioProvider = ({ children }) => {
 
 // 明示的にデフォルトエクスポートも追加
 export default PortfolioContext;
+
+// テスト用にユーティリティ関数を明示的にエクスポート
+export { encryptData, decryptData };


### PR DESCRIPTION
## Summary
- export encrypt/decrypt helpers from `PortfolioContext`
- add unit tests covering `encryptData`, `decryptData`, `exportData` and `validateAssetTypes`
- document new test file in `test-files.md`

## Testing
- `./scripts/run-tests.sh all` *(fails: cross-env not found and network access blocked)*